### PR TITLE
feat: bring Svartz to blog MVP readiness

### DIFF
--- a/apps/web/project.inlang/settings.json
+++ b/apps/web/project.inlang/settings.json
@@ -8,5 +8,5 @@
 		"pathPattern": "./messages/{locale}.json"
 	},
 	"baseLocale": "en",
-	"locales": ["en", "nl"]
+	"locales": ["en"]
 }

--- a/apps/web/src/lib/svartz/SvartzRuntimePage.svelte
+++ b/apps/web/src/lib/svartz/SvartzRuntimePage.svelte
@@ -14,6 +14,7 @@
 		search,
 		searchDocuments,
 		searchIndex,
+		siteConfig,
 		tags,
 		themeConfig
 	} from 'virtual:svartz/artifacts';
@@ -83,6 +84,11 @@
 		return resolveComponentModule(theme.layouts.notFoundPage);
 	}
 
+	function resolveAbsoluteUrl(value: string | undefined): string | undefined {
+		if (!value || !siteConfig.url) return undefined;
+		return new URL(value, `${siteConfig.url}/`).href;
+	}
+
 	const activePathname = $derived(pathname ?? page.url.pathname);
 
 	const runtimeRoute = $derived(
@@ -100,6 +106,14 @@
 			: undefined
 	);
 
+	const pageTitle = $derived(entry?.title ?? siteConfig.title);
+	const documentTitle = $derived(
+		entry && entry.title !== siteConfig.title ? `${entry.title} | ${siteConfig.title}` : siteConfig.title
+	);
+	const pageDescription = $derived(entry?.description ?? siteConfig.description);
+	const canonicalUrl = $derived(resolveAbsoluteUrl(activePathname));
+	const socialImageUrl = $derived(resolveAbsoluteUrl(siteConfig.image));
+
 	const layoutModule = $derived(
 		resolveComponentModule(resolveLayoutReference(runtimeRoute))
 	);
@@ -107,6 +121,24 @@
 	const LayoutComponent = $derived(layoutModule?.default);
 	const PageComponent = $derived(pageModule?.default);
 </script>
+
+<svelte:head>
+	<title>{documentTitle}</title>
+	{#if pageDescription}<meta name="description" content={pageDescription} />{/if}
+	{#if canonicalUrl}<link rel="canonical" href={canonicalUrl} />{/if}
+	<meta property="og:title" content={pageTitle} />
+	{#if pageDescription}<meta property="og:description" content={pageDescription} />{/if}
+	<meta property="og:type" content={entry ? 'article' : 'website'} />
+	{#if canonicalUrl}<meta property="og:url" content={canonicalUrl} />{/if}
+	{#if socialImageUrl}<meta property="og:image" content={socialImageUrl} />{/if}
+	<meta name="twitter:card" content={socialImageUrl ? 'summary_large_image' : 'summary'} />
+	<meta name="twitter:title" content={pageTitle} />
+	{#if pageDescription}<meta name="twitter:description" content={pageDescription} />{/if}
+	{#if socialImageUrl}<meta name="twitter:image" content={socialImageUrl} />{/if}
+	{#if siteConfig.author}<meta name="author" content={siteConfig.author} />{/if}
+	{#if entry?.publishedAt}<meta property="article:published_time" content={String(entry.publishedAt)} />{/if}
+	{#if entry?.modifiedAt}<meta property="article:modified_time" content={String(entry.modifiedAt)} />{/if}
+</svelte:head>
 
 {#if LayoutComponent && PageComponent}
 	<LayoutComponent

--- a/apps/web/src/lib/svartz/SvartzRuntimePage.svelte
+++ b/apps/web/src/lib/svartz/SvartzRuntimePage.svelte
@@ -6,9 +6,10 @@
 		assets,
 		backlinks,
 		folders,
+		getNoteArtifact,
 		graph,
+		hasNoteArtifact,
 		index,
-		loadNoteArtifact,
 		routes,
 		search,
 		searchDocuments,
@@ -18,7 +19,7 @@
 	} from 'virtual:svartz/artifacts';
 
 	type ComponentModule = { default: Component<any> };
-	type ThemeComponentLoader =
+	type ThemeComponentReference =
 		| (() => Promise<ComponentModule>)
 		| { readonly default: Component<any> };
 	type RuntimeRouteMatch = ReturnType<typeof resolveRuntimeRoute>;
@@ -35,16 +36,20 @@
 	}
 
 	function resolveComponentModule(
-		loader: ThemeComponentLoader | undefined
-	): Promise<ComponentModule | undefined> {
-		if (!loader) return Promise.resolve(undefined);
-		if (typeof loader === 'function') {
-			return loader() as Promise<ComponentModule>;
+		reference: ThemeComponentReference | undefined
+	): ComponentModule | undefined {
+		if (!reference) return undefined;
+		if (typeof reference === 'function') {
+			throw new Error(
+				'[svartz:web] lazy theme components cannot render during SSR; use an eager { default: Component } module'
+			);
 		}
-		return Promise.resolve(loader as ComponentModule);
+		return reference;
 	}
 
-	function resolveLayoutLoader(match: RuntimeRouteMatch): ThemeComponentLoader | undefined {
+	function resolveLayoutReference(
+		match: RuntimeRouteMatch
+	): ThemeComponentReference | undefined {
 		if (match?.layoutSlot && theme.layouts[match.layoutSlot]) {
 			return theme.layouts[match.layoutSlot];
 		}
@@ -56,7 +61,7 @@
 		return theme.layouts.defaultPage;
 	}
 
-	function resolvePageModule(match: RuntimeRouteMatch): Promise<ComponentModule | undefined> {
+	function resolvePageModule(match: RuntimeRouteMatch): ComponentModule | undefined {
 		if (!match) {
 			return resolveComponentModule(theme.layouts.notFoundPage);
 		}
@@ -65,11 +70,17 @@
 			return resolveComponentModule(match.route.component);
 		}
 
-		if (match.artifactKey) {
-			return loadNoteArtifact(match.artifactKey) as Promise<ComponentModule>;
+		if (match.artifactKey && hasNoteArtifact(match.artifactKey)) {
+			return getNoteArtifact(match.artifactKey);
 		}
 
-		return Promise.resolve(undefined);
+		const slug = artifactKeyToSlug(match.artifactKey);
+		if (slug && folders.some((folder) => folder.slug === slug)) {
+			const folderRoute = theme.routes.find((route) => route.id === 'folder');
+			return resolveComponentModule(folderRoute?.component);
+		}
+
+		return resolveComponentModule(theme.layouts.notFoundPage);
 	}
 
 	const activePathname = $derived(pathname ?? page.url.pathname);
@@ -89,26 +100,34 @@
 			: undefined
 	);
 
-	const renderState = $derived.by(async () => {
-		const [layout, pageModule] = await Promise.all([
-			resolveComponentModule(resolveLayoutLoader(runtimeRoute)),
-			resolvePageModule(runtimeRoute)
-		]);
-
-		return { layout, pageModule };
-	});
+	const layoutModule = $derived(
+		resolveComponentModule(resolveLayoutReference(runtimeRoute))
+	);
+	const pageModule = $derived(resolvePageModule(runtimeRoute));
+	const LayoutComponent = $derived(layoutModule?.default);
+	const PageComponent = $derived(pageModule?.default);
 </script>
 
-{#await renderState}
-	<div aria-live="polite">Loading...</div>
-{:then rendered}
-	{@const LayoutComponent = rendered.layout?.default}
-	{@const PageComponent = rendered.pageModule?.default}
-
-	{#if LayoutComponent && PageComponent}
-		<LayoutComponent
+{#if LayoutComponent && PageComponent}
+	<LayoutComponent
+		{assets}
+		{theme}
+		{themeConfig}
+		route={runtimeRoute?.route}
+		match={runtimeRoute}
+		{entry}
+		{index}
+		{graph}
+		{backlinks}
+		{folders}
+		{routes}
+		{search}
+		{searchDocuments}
+		{searchIndex}
+		{tags}
+	>
+		<PageComponent
 			{assets}
-			{theme}
 			{themeConfig}
 			route={runtimeRoute?.route}
 			match={runtimeRoute}
@@ -122,27 +141,8 @@
 			{searchDocuments}
 			{searchIndex}
 			{tags}
-		>
-			<PageComponent
-				{assets}
-				{themeConfig}
-				route={runtimeRoute?.route}
-				match={runtimeRoute}
-				{entry}
-				{index}
-				{graph}
-				{backlinks}
-				{folders}
-				{routes}
-				{search}
-				{searchDocuments}
-				{searchIndex}
-				{tags}
-			/>
-		</LayoutComponent>
-	{:else}
-		<p>Route component unavailable.</p>
-	{/if}
-{:catch error}
-	<p>{error instanceof Error ? error.message : 'Failed to load page.'}</p>
-{/await}
+		/>
+	</LayoutComponent>
+{:else}
+	<p>Route component unavailable.</p>
+{/if}

--- a/apps/web/src/lib/svartz/SvartzRuntimePage.test.ts
+++ b/apps/web/src/lib/svartz/SvartzRuntimePage.test.ts
@@ -4,10 +4,15 @@ import SvartzRuntimePage from './SvartzRuntimePage.svelte';
 
 describe('SvartzRuntimePage SSR', () => {
 	it('renders the layout and note content without a loading placeholder', () => {
-		const { body } = render(SvartzRuntimePage, { props: { pathname: '/' } });
+		const { body, head } = render(SvartzRuntimePage, { props: { pathname: '/' } });
 
 		expect(body).toContain('Svartz test layout');
 		expect(body).toContain('Svartz test page');
 		expect(body).not.toContain('Loading...');
+		expect(head).toContain('<title>Svartz test page | Svartz Test</title>');
+		expect(head).toContain('name="description" content="Runtime shell test page."');
+		expect(head).toContain('rel="canonical" href="https://example.com/"');
+		expect(head).toContain('property="og:title" content="Svartz test page"');
+		expect(head).toContain('name="twitter:card" content="summary_large_image"');
 	});
 });

--- a/apps/web/src/lib/svartz/SvartzRuntimePage.test.ts
+++ b/apps/web/src/lib/svartz/SvartzRuntimePage.test.ts
@@ -1,0 +1,13 @@
+import { render } from 'svelte/server';
+import { describe, expect, it } from 'vitest';
+import SvartzRuntimePage from './SvartzRuntimePage.svelte';
+
+describe('SvartzRuntimePage SSR', () => {
+	it('renders the layout and note content without a loading placeholder', () => {
+		const { body } = render(SvartzRuntimePage, { props: { pathname: '/' } });
+
+		expect(body).toContain('Svartz test layout');
+		expect(body).toContain('Svartz test page');
+		expect(body).not.toContain('Loading...');
+	});
+});

--- a/apps/web/src/lib/svartz/testing/fixtures/runtime-artifacts.ts
+++ b/apps/web/src/lib/svartz/testing/fixtures/runtime-artifacts.ts
@@ -32,3 +32,10 @@ export const folders = index.folders;
 export const routes = index.routes;
 export const assets = index.assets;
 export const themeConfig: Record<string, unknown> = {};
+export const siteConfig = {
+	title: 'Svartz Test',
+	description: 'A test vault',
+	url: 'https://example.com',
+	author: 'Svartz',
+	image: '/social.png'
+};

--- a/apps/web/src/lib/svartz/testing/fixtures/runtime-artifacts.ts
+++ b/apps/web/src/lib/svartz/testing/fixtures/runtime-artifacts.ts
@@ -13,7 +13,11 @@ export const artifacts = new Map([
 	]
 ]);
 
-export async function loadNoteArtifact(_key: string) {
+export function hasNoteArtifact(_key: string) {
+	return true;
+}
+
+export function getNoteArtifact(_key: string) {
 	return { default: StubPage };
 }
 

--- a/apps/web/src/lib/svartz/virtual-modules.d.ts
+++ b/apps/web/src/lib/svartz/virtual-modules.d.ts
@@ -131,5 +131,12 @@ declare module 'virtual:svartz/artifacts' {
 	export const searchDocuments: readonly RuntimeSearchDocument[];
 	export const searchIndex: unknown;
 	/** Vault-level theme config (everything under `theme:` in svartz.config, minus `base`). */
-	export const themeConfig: Record<string, unknown>;
+	export const themeConfig: Readonly<Record<string, unknown>>;
+	export const siteConfig: Readonly<{
+		title: string;
+		description?: string;
+		url?: string;
+		author?: string;
+		image?: string;
+	}>;
 }

--- a/apps/web/src/lib/svartz/virtual-modules.d.ts
+++ b/apps/web/src/lib/svartz/virtual-modules.d.ts
@@ -96,9 +96,10 @@ declare module 'virtual:svartz/artifacts' {
 	}
 
 	export const artifacts: ReadonlyMap<string, RuntimeArtifactRecord>;
-	export function loadNoteArtifact(
+	export function hasNoteArtifact(key: string): boolean;
+	export function getNoteArtifact(
 		key: string
-	): Promise<{ default: Component<any> }>;
+	): { default: Component<any> };
 	export const index: {
 		readonly version: string;
 		readonly entries: readonly RuntimeIndexEntry[];

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,6 +1,4 @@
 <script lang="ts">
-	import { page } from '$app/state';
-	import { locales, localizeHref } from '$lib/paraglide/runtime';
 	import './layout.css';
 	import favicon from '$lib/assets/favicon.svg';
 
@@ -9,9 +7,3 @@
 
 <svelte:head><link rel="icon" href={favicon} /></svelte:head>
 {@render children()}
-
-<div style="display:none">
-	{#each locales as locale}
-		<a href={localizeHref(page.url.pathname, { locale })}>{locale}</a>
-	{/each}
-</div>

--- a/apps/web/src/routes/sitemap.xml/+server.ts
+++ b/apps/web/src/routes/sitemap.xml/+server.ts
@@ -1,0 +1,29 @@
+import { index, siteConfig } from 'virtual:svartz/artifacts';
+
+export const prerender = true;
+
+function escapeXml(value: string): string {
+	return value
+		.replaceAll('&', '&amp;')
+		.replaceAll('<', '&lt;')
+		.replaceAll('>', '&gt;')
+		.replaceAll('"', '&quot;')
+		.replaceAll("'", '&apos;');
+}
+
+export function GET(): Response {
+	const baseUrl = siteConfig.url?.replace(/\/+$/, '');
+	const urls = baseUrl
+		? index.entries.map((entry) => {
+				const pathname = entry.slug === 'index' ? '/' : `/${entry.slug}/`;
+				const location = escapeXml(`${baseUrl}${pathname}`);
+				const lastModified = new Date(entry.modifiedAt).toISOString();
+				return `  <url><loc>${location}</loc><lastmod>${lastModified}</lastmod></url>`;
+			})
+		: [];
+
+	return new Response(
+		['<?xml version="1.0" encoding="UTF-8"?>', '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', ...urls, '</urlset>', ''].join('\n'),
+		{ headers: { 'content-type': 'application/xml; charset=utf-8' } }
+	);
+}

--- a/apps/web/src/routes/sitemap.xml/server.test.ts
+++ b/apps/web/src/routes/sitemap.xml/server.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { GET } from './+server';
+
+describe('sitemap.xml', () => {
+	it('emits canonical note URLs and modification dates', async () => {
+		const response = GET();
+		const xml = await response.text();
+
+		expect(response.headers.get('content-type')).toContain('application/xml');
+		expect(xml).toContain('<loc>https://example.com/</loc>');
+		expect(xml).toContain('<lastmod>');
+		expect(xml).not.toContain('https://example.com/index/');
+	});
+});

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -25,6 +25,7 @@ function resolveAdapter(target) {
 			return adapterStatic({
 				pages: outDir,
 				assets: outDir,
+				fallback: '404.html',
 				strict: true
 			});
 	}

--- a/apps/web/svelte.config.js
+++ b/apps/web/svelte.config.js
@@ -37,6 +37,9 @@ const config = {
 		outDir: kitOutDir,
 		paths: {
 			base: basePath
+		},
+		prerender: {
+			handleMissingId: 'warn'
 		}
 	},
 	preprocess: [mdsvex()],

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "svartz": "svartz",
-    "prebuild": "pnpm install",
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
@@ -23,14 +22,8 @@
     "svartz:build:docs": "svartz build --vault docs",
     "svartz:dev:docs": "svartz dev --vault docs",
     "svartz:preview:docs": "svartz preview --vault docs",
-    "svartz:build:obsidian-journal": "svartz build --vault obsidian-journal",
-    "svartz:dev:obsidian-journal": "svartz dev --vault obsidian-journal",
-    "svartz:preview:obsidian-journal": "svartz preview --vault obsidian-journal",
-    "svartz:build:vault": "svartz build --vault vault",
-    "svartz:dev:vault": "svartz dev --vault vault",
-    "svartz:preview:vault": "svartz preview --vault vault",
-    "svartz:dev": "turbo run svartz:dev:docs svartz:dev:obsidian-journal svartz:dev:vault",
-    "svartz:preview": "turbo run svartz:preview:docs svartz:preview:obsidian-journal svartz:preview:vault"
+    "svartz:dev": "turbo run svartz:dev:docs",
+    "svartz:preview": "turbo run svartz:preview:docs"
   },
   "devDependencies": {
     "@svartz/config": "workspace:^",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -2,7 +2,7 @@
 
 import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import { existsSync } from "node:fs";
-import { cp, lstat, mkdir, readlink, rm, rmdir, stat, symlink } from "node:fs/promises";
+import { cp, lstat, mkdir, readFile, readlink, rm, stat, symlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import chokidar, { type FSWatcher } from "chokidar";
@@ -301,6 +301,23 @@ const ensureVaultKitSymlink = (
     catch: (cause) => cause as Error,
   });
 
+const removeVaultKitSymlink = async (
+  appRoot: string,
+  vault: ResolvedConfig,
+): Promise<void> => {
+  const appKitPath = path.join(appRoot, ".svelte-kit");
+  try {
+    const existing = await lstat(appKitPath);
+    if (!existing.isSymbolicLink()) return;
+    const resolvedTarget = path.resolve(appRoot, await readlink(appKitPath));
+    if (resolvedTarget === kitOutDirForVault(vault)) {
+      await rm(appKitPath, { force: true });
+    }
+  } catch (cause) {
+    if ((cause as NodeJS.ErrnoException).code !== "ENOENT") throw cause;
+  }
+};
+
 const ensureDirectory = (directory: string) =>
   Effect.tryPromise({
     try: async () => {
@@ -509,6 +526,30 @@ const copyVaultAssets = (vault: ResolvedConfig): Effect.Effect<void, CliError> =
 
 const VAULT_BUILD_LOCK_RETRY_MS = 1000;
 const VAULT_BUILD_LOCK_MAX_WAIT_MS = 600_000; // 10 min
+const VAULT_BUILD_LOCK_ORPHAN_GRACE_MS = 5_000;
+
+const isProcessRunning = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code !== "ESRCH";
+  }
+};
+
+const isStaleVaultBuildLock = async (lockDir: string): Promise<boolean> => {
+  try {
+    const owner = JSON.parse(
+      await readFile(path.join(lockDir, "owner.json"), "utf8"),
+    ) as { pid?: unknown };
+    return typeof owner.pid !== "number" || !isProcessRunning(owner.pid);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT" && !(error instanceof SyntaxError)) throw error;
+    const lockStat = await stat(lockDir);
+    return Date.now() - lockStat.mtimeMs >= VAULT_BUILD_LOCK_ORPHAN_GRACE_MS;
+  }
+};
 
 const withVaultBuildLock = (
   appRoot: string,
@@ -516,20 +557,33 @@ const withVaultBuildLock = (
 ): Promise<void> =>
   new Promise((resolve, reject) => {
     const workspaceRoot = path.resolve(appRoot, "../..");
-    const lockDir = path.join(workspaceRoot, ".svartz", ".vault-build.lock");
+    const lockRoot = path.join(workspaceRoot, ".svartz");
+    const lockDir = path.join(lockRoot, ".vault-build.lock");
     let waited = 0;
 
     const tryAcquire = (): void => {
-      mkdir(lockDir, { recursive: false })
-        .then(() =>
-          fn().finally(() =>
-            rmdir(lockDir).catch(() => {
-              /* ignore stale lock cleanup failure */
-            }),
-          ),
-        )
-        .then(resolve, (err: NodeJS.ErrnoException) => {
-          if (err.code === "EEXIST" && waited < VAULT_BUILD_LOCK_MAX_WAIT_MS) {
+      mkdir(lockRoot, { recursive: true })
+        .then(() => mkdir(lockDir, { recursive: false }))
+        .then(async () => {
+          await writeFile(
+            path.join(lockDir, "owner.json"),
+            JSON.stringify({ pid: process.pid, createdAt: new Date().toISOString() }),
+          );
+          return fn().finally(() => rm(lockDir, { recursive: true, force: true }));
+        })
+        .then(resolve, async (err: NodeJS.ErrnoException) => {
+          if (err.code !== "EEXIST") {
+            reject(err);
+            return;
+          }
+
+          if (await isStaleVaultBuildLock(lockDir).catch(() => false)) {
+            await rm(lockDir, { recursive: true, force: true });
+            tryAcquire();
+            return;
+          }
+
+          if (waited < VAULT_BUILD_LOCK_MAX_WAIT_MS) {
             waited += VAULT_BUILD_LOCK_RETRY_MS;
             setTimeout(tryAcquire, VAULT_BUILD_LOCK_RETRY_MS);
           } else {
@@ -550,12 +604,16 @@ const buildVault = (
     yield* Effect.tryPromise({
       try: () =>
         withVaultBuildLock(appRoot, async () => {
-          const config = await runEffect(
-            createAppConfig(appRoot, supportedVault, "production", "build"),
-          );
-          await viteBuild(config);
-          if (supportedVault.target.type === "static") {
-            await runEffect(copyVaultAssets(supportedVault));
+          try {
+            const config = await runEffect(
+              createAppConfig(appRoot, supportedVault, "production", "build"),
+            );
+            await viteBuild(config);
+            if (supportedVault.target.type === "static") {
+              await runEffect(copyVaultAssets(supportedVault));
+            }
+          } finally {
+            await removeVaultKitSymlink(appRoot, supportedVault);
           }
         }),
       catch: (cause) => cause as Error,

--- a/packages/cli/tests/build.e2e.test.ts
+++ b/packages/cli/tests/build.e2e.test.ts
@@ -1,4 +1,4 @@
-import { access, rm } from "node:fs/promises";
+import { access, readFile, rm } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -7,47 +7,50 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 const execFileAsync = promisify(execFile);
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../../..");
-const DIST_INDEX_PATHS = [
-  ".svartz/vaults/docs/dist/index.html",
-  ".svartz/vaults/obsidian-journal/dist/index.html",
-  ".svartz/vaults/vault/dist/index.html",
-].map((relativePath) => resolve(ROOT, relativePath));
+const DIST_ROOT = resolve(ROOT, ".svartz/vaults/docs/dist");
+const DIST_INDEX_PATH = resolve(DIST_ROOT, "index.html");
+const DIST_NOT_FOUND_PATH = resolve(DIST_ROOT, "404.html");
+const DIST_SITEMAP_PATH = resolve(DIST_ROOT, "sitemap.xml");
 
 async function run(command: string, args: string[]) {
   await execFileAsync(command, args, {
     cwd: ROOT,
     env: process.env,
-    maxBuffer: 10 * 1024 * 1024,
+    maxBuffer: 20 * 1024 * 1024,
   });
+}
+
+async function pnpm(args: string[]) {
+  await run("corepack", ["pnpm", ...args]);
 }
 
 describe("svartz CLI", () => {
   beforeAll(
     async () => {
-      await run("pnpm", ["--filter", "@svartz/config", "build"]);
-      await run("pnpm", ["--filter", "@svartz/plugins", "build"]);
-      await run("pnpm", ["--filter", "@svartz/vite", "build"]);
-      await run("pnpm", ["--filter", "svartz", "build"]);
+      await pnpm(["--filter", "@svartz/core", "build"]);
+      await pnpm(["--filter", "@svartz/config", "build"]);
+      await pnpm(["--filter", "@svartz/plugins", "build"]);
+      await pnpm(["--filter", "@svartz/vite", "build"]);
+      await pnpm(["--filter", "svartz", "build"]);
     },
     240_000,
   );
 
   it(
-    "builds all configured vaults when no --vault flag is provided",
+    "builds prerendered docs from a clean output directory",
     async () => {
-      await Promise.all(
-        DIST_INDEX_PATHS.map((indexPath) =>
-          rm(dirname(indexPath), { recursive: true, force: true }),
-        ),
-      );
+      await rm(DIST_ROOT, { recursive: true, force: true });
 
-      await run("node", ["packages/cli/dist/index.js", "build"]);
+      await run(process.execPath, ["packages/cli/dist/index.js", "build", "--vault", "docs"]);
 
-      await Promise.all(
-        DIST_INDEX_PATHS.map(async (indexPath) => {
-          await expect(access(indexPath)).resolves.toBeUndefined();
-        }),
-      );
+      await expect(access(DIST_INDEX_PATH)).resolves.toBeUndefined();
+      await expect(access(DIST_NOT_FOUND_PATH)).resolves.toBeUndefined();
+      await expect(access(DIST_SITEMAP_PATH)).resolves.toBeUndefined();
+
+      const html = await readFile(DIST_INDEX_PATH, "utf8");
+      expect(html).toContain("<title>");
+      expect(html).toContain("<h1");
+      expect(html).not.toContain('aria-live="polite">Loading');
     },
     240_000,
   );

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,14 +31,15 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "@types/semver": "^7.7.1",
+    "@vitest/coverage-v8": "^3.0.0",
     "tsup": "^8.0.0",
     "typescript": "^5.0.0",
-    "@vitest/coverage-v8": "^3.0.0",
     "vitest": "^3.0.0"
   },
   "dependencies": {
     "@svartz/core": "workspace:^",
     "effect": "^3.19.19",
+    "jiti": "^2.7.0",
     "semver": "^7.7.4",
     "wrangler": "^4.69.0"
   }

--- a/packages/config/src/loader.ts
+++ b/packages/config/src/loader.ts
@@ -1,7 +1,7 @@
 import { Effect, Schema } from "effect";
 import { access, stat } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
-import { pathToFileURL } from "node:url";
+import { createJiti } from "jiti";
 import { major as semverMajor } from "semver";
 import { resolveConfig } from "./resolver";
 import { SvartzConfigSchema } from "./schemas";
@@ -121,10 +121,8 @@ const importConfig = (
 ): Effect.Effect<unknown, ConfigImportFailed> =>
   Effect.tryPromise({
     try: async () => {
-      const fileUrl = pathToFileURL(configPath);
-      const configStat = await stat(configPath);
-      fileUrl.searchParams.set("t", String(configStat.mtimeMs));
-      const mod = (await import(fileUrl.href)) as Record<string, unknown>;
+      const jiti = createJiti(import.meta.url, { moduleCache: false });
+      const mod = (await jiti.import(configPath)) as Record<string, unknown>;
       return mod["default"] ?? mod;
     },
     catch: (cause) =>

--- a/packages/config/src/resolver.ts
+++ b/packages/config/src/resolver.ts
@@ -9,7 +9,9 @@ import type {
   ResolvedConfig,
   ResolvedConfigSet,
   ResolvedFrontmatterConfig,
+  ResolvedSiteConfig,
   ResolvedThemeConfig,
+  SiteConfig,
   SvartzConfig,
   SvartzDefaults,
   VaultConfig,
@@ -47,6 +49,7 @@ const DEFAULT_FRONTMATTER: ResolvedFrontmatterConfig = {
   createdAtField: "created_at",
   updatedAtField: "updated_at",
   publishedField: "published",
+  publicationMode: "opt-out",
 };
 
 // --- Theme normalization ---
@@ -79,6 +82,18 @@ const mergeFrontmatter = (
     ...defaultFm,
     ...vaultFm,
   }) as ResolvedFrontmatterConfig;
+
+const mergeSite = (
+  defaultSite: SiteConfig | undefined,
+  vaultSite: SiteConfig | undefined,
+  vaultId: string,
+): ResolvedSiteConfig => {
+  const merged = { title: vaultId, ...defaultSite, ...vaultSite };
+  return {
+    ...merged,
+    ...(merged.url !== undefined && { url: merged.url.replace(/\/+$/, "") }),
+  };
+};
 
 // --- Build defaults ---
 
@@ -146,6 +161,7 @@ const resolveVaultConfig = (
         DEFAULT_LINK_RESOLUTION,
       theme: mergeThemes(defaults?.theme, vault.theme),
       frontmatter: mergeFrontmatter(defaults?.frontmatter, vault.frontmatter),
+      site: mergeSite(defaults?.site, vault.site, vault.id),
       target: vault.target,
       plugins,
     };

--- a/packages/config/src/schemas/svartz.ts
+++ b/packages/config/src/schemas/svartz.ts
@@ -23,7 +23,27 @@ const FrontmatterFieldsSchema = Schema.Struct({
   createdAtField: Schema.optional(Schema.String),
   updatedAtField: Schema.optional(Schema.String),
   publishedField: Schema.optional(Schema.String),
+  publicationMode: Schema.optional(Schema.Literal("opt-out", "explicit")),
   dateFormat: Schema.optional(Schema.String),
+});
+
+const HttpUrlSchema = Schema.String.pipe(
+  Schema.filter((value) => {
+    try {
+      const url = new URL(value);
+      return url.protocol === "http:" || url.protocol === "https:";
+    } catch {
+      return false;
+    }
+  }, { message: () => "site.url must be an absolute HTTP(S) URL" }),
+);
+
+const SiteConfigSchema = Schema.Struct({
+  title: Schema.String,
+  description: Schema.optional(Schema.String),
+  url: Schema.optional(HttpUrlSchema),
+  author: Schema.optional(Schema.String),
+  image: Schema.optional(Schema.String),
 });
 
 /** Shallow plugin placeholder; plugin interface/standard TBD. */
@@ -36,6 +56,7 @@ const VaultOptionsSchema = Schema.Struct({
   linkResolution: Schema.optional(LinkResolutionStrategySchema),
   theme: Schema.optional(VaultThemeConfigSchema),
   frontmatter: Schema.optional(FrontmatterFieldsSchema),
+  site: Schema.optional(SiteConfigSchema),
   /** Output directory for this vault's build artifact. Default: `.svartz/vaults/<vault.id>`. */
   outDir: Schema.optional(Schema.String),
   /** Plugin instances (transformers, filters, emitters). Vault- and theme-specific. Shape TBD when plugin API is defined. */
@@ -79,6 +100,7 @@ const VaultConfigSchema = Schema.Struct({
   linkResolution: Schema.optional(LinkResolutionStrategySchema),
   theme: Schema.optional(VaultThemeConfigSchema),
   frontmatter: Schema.optional(FrontmatterFieldsSchema),
+  site: Schema.optional(SiteConfigSchema),
   outDir: Schema.optional(Schema.String),
   plugins: Schema.optional(Schema.Array(PluginEntrySchema)),
 });
@@ -99,6 +121,7 @@ export {
   LinkResolutionStrategySchema,
   VaultThemeConfigSchema,
   FrontmatterFieldsSchema,
+  SiteConfigSchema,
   PluginEntrySchema,
   VaultOptionsSchema,
   TargetConfigSchema,

--- a/packages/config/src/types/config.ts
+++ b/packages/config/src/types/config.ts
@@ -8,6 +8,7 @@ import type {
   TargetConfigSchema,
   LinkResolutionStrategySchema,
   FrontmatterFieldsSchema,
+  SiteConfigSchema,
 } from "../schemas";
 
 // --- Inferred types from Schema ---
@@ -26,6 +27,7 @@ type LinkResolutionStrategy = Schema.Schema.Type<
 type FrontmatterFields = Schema.Schema.Type<
   typeof FrontmatterFieldsSchema
 >;
+type SiteConfig = Schema.Schema.Type<typeof SiteConfigSchema>;
 
 export {
   type SvartzConfig,
@@ -36,4 +38,5 @@ export {
   type TargetConfig,
   type LinkResolutionStrategy,
   type FrontmatterFields,
+  type SiteConfig,
 };

--- a/packages/config/src/types/resolved.ts
+++ b/packages/config/src/types/resolved.ts
@@ -2,6 +2,7 @@ import type {
   ResolvedBuildConfig,
   ResolvedConfig as CoreResolvedConfig,
   ResolvedFrontmatterConfig,
+  ResolvedSiteConfig,
   ResolvedThemeConfig,
   ResolvedVaultDefaults,
 } from "@svartz/core";
@@ -31,6 +32,7 @@ export {
   type ResolvedConfig,
   type ResolvedConfigSet,
   type ResolvedFrontmatterConfig,
+  type ResolvedSiteConfig,
   type ResolvedThemeConfig,
   type ResolvedVaultConfig,
   type ResolvedVaultDefaults,

--- a/packages/config/tests/fixtures/configs/valid-typescript.ts
+++ b/packages/config/tests/fixtures/configs/valid-typescript.ts
@@ -1,0 +1,15 @@
+const config: {
+  version: string;
+  vaults: Array<{ id: string; path: string; target: { type: "static" } }>;
+} = {
+  version: "1.0.0",
+  vaults: [
+    {
+      id: "main",
+      path: "../valid-vault",
+      target: { type: "static" },
+    },
+  ],
+};
+
+export default config;

--- a/packages/config/tests/loader.test.ts
+++ b/packages/config/tests/loader.test.ts
@@ -33,6 +33,53 @@ describe("parseConfig", () => {
     }
   });
 
+  it("accepts site metadata on a vault", async () => {
+    const result = await parseConfig({
+      version: "1.0.0",
+      vaults: [
+        {
+          id: "blog",
+          path: "blog",
+          target: { type: "static" },
+          site: {
+            title: "Patch Notes",
+            description: "Writing by Mia",
+            url: "https://example.com",
+            author: "Mia",
+            image: "/social.png",
+          },
+        },
+      ],
+    });
+
+    expect(result.vaults[0]!.site).toEqual({
+      title: "Patch Notes",
+      description: "Writing by Mia",
+      url: "https://example.com",
+      author: "Mia",
+      image: "/social.png",
+    });
+  });
+
+  it.each(["example.com", "ftp://example.com", "/blog", "not a url"])(
+    "rejects non-HTTP site URL %s",
+    async (url) => {
+      await expect(
+        parseConfig({
+          version: "1.0.0",
+          vaults: [
+            {
+              id: "blog",
+              path: "blog",
+              target: { type: "static" },
+              site: { title: "Patch Notes", url },
+            },
+          ],
+        }),
+      ).rejects.toThrow(ConfigDecodeFailed);
+    },
+  );
+
   it("throws ConfigDecodeFailed on wrong major version", async () => {
     await expect(
       parseConfig({
@@ -61,6 +108,11 @@ describe("loadConfig", () => {
     const config = await loadConfig(configPath);
     expect(config.configDir).toBe(FIXTURES);
     expect(config.vaults).toHaveLength(1);
+    expect(config.vaults[0]!.id).toBe("main");
+  });
+
+  it("loads TypeScript config files on the supported Node baseline", async () => {
+    const config = await loadConfig(resolve(FIXTURES, "valid-typescript.ts"));
     expect(config.vaults[0]!.id).toBe("main");
   });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,7 @@ export type {
   TargetConfig,
   ResolvedConfig,
   ResolvedFrontmatterConfig,
+  ResolvedSiteConfig,
   ResolvedThemeConfig,
   ResolvedBuildConfig,
   ResolvedVaultDefaults,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,12 +21,21 @@ interface ResolvedFrontmatterConfig {
   readonly createdAtField: string;
   readonly updatedAtField: string;
   readonly publishedField: string;
+  readonly publicationMode: "opt-out" | "explicit";
   readonly dateFormat?: string;
 }
 
 interface ResolvedThemeConfig {
   readonly base: string;
   readonly [key: string]: unknown;
+}
+
+interface ResolvedSiteConfig {
+  readonly title: string;
+  readonly description?: string;
+  readonly url?: string;
+  readonly author?: string;
+  readonly image?: string;
 }
 
 interface ResolvedBuildConfig {
@@ -40,6 +49,7 @@ interface ResolvedVaultDefaults {
   readonly linkResolution: LinkResolutionStrategy;
   readonly theme: ResolvedThemeConfig;
   readonly frontmatter: ResolvedFrontmatterConfig;
+  readonly site: ResolvedSiteConfig;
 }
 
 /** Canonical single-vault build config consumed by the runner and @svartz/vite. */
@@ -54,6 +64,7 @@ interface ResolvedConfig {
   readonly linkResolution: LinkResolutionStrategy;
   readonly theme: ResolvedThemeConfig;
   readonly frontmatter: ResolvedFrontmatterConfig;
+  readonly site: ResolvedSiteConfig;
   readonly target: TargetConfig;
   readonly plugins: readonly unknown[];
 }
@@ -230,6 +241,7 @@ export type {
   ResolvedBuildConfig,
   ResolvedConfig,
   ResolvedFrontmatterConfig,
+  ResolvedSiteConfig,
   ResolvedThemeConfig,
   ResolvedVaultDefaults,
   RouteIndex,

--- a/packages/plugins/src/emit-artifacts.ts
+++ b/packages/plugins/src/emit-artifacts.ts
@@ -14,15 +14,15 @@ import rehypeAutolinkHeadings from "rehype-autolink-headings";
 import rehypeKatex from "rehype-katex";
 import rehypePrettyCode from "rehype-pretty-code";
 import rehypeSlug from "rehype-slug";
-import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { definePlugin, type Artifact, type Index } from "@svartz/core";
+import { MDSVEX_REMARK_PLUGINS_META_KEY } from "./transform-gfm";
 
 type MdsvexOptions = NonNullable<Parameters<typeof compile>[1]>;
 
-const REMARK_PLUGINS = [remarkGfm, remarkMath] as MdsvexOptions["remarkPlugins"];
+const BASE_REMARK_PLUGINS = [remarkMath] as MdsvexOptions["remarkPlugins"];
 const REHYPE_PLUGINS = [
   rehypeSlug,
   [
@@ -69,12 +69,15 @@ function serializeValue(value: unknown): string {
   return JSON.stringify(value);
 }
 
-async function compileNoteComponent(file: {
-  readonly path: string;
-  readonly slug: string;
-  readonly content: string;
-  readonly frontmatter?: Record<string, unknown>;
-}): Promise<string> {
+async function compileNoteComponent(
+  file: {
+    readonly path: string;
+    readonly slug: string;
+    readonly content: string;
+    readonly frontmatter?: Record<string, unknown>;
+  },
+  remarkPlugins: MdsvexOptions["remarkPlugins"],
+): Promise<string> {
   const source = [
     "<script context=\"module\" lang=\"ts\">",
     `export const svartz = ${serializeValue({
@@ -89,7 +92,7 @@ async function compileNoteComponent(file: {
 
   const result = await compile(source, {
     extension: ".svx",
-    remarkPlugins: REMARK_PLUGINS,
+    remarkPlugins,
     rehypePlugins: REHYPE_PLUGINS,
   });
   return result?.code ?? source;
@@ -132,6 +135,11 @@ export const emitArtifacts = definePlugin(() => ({
       if (!ctx.index) return;
 
       const artifactsRoot = getArtifactsRoot(ctx.config.outDir);
+      const configuredRemarkPlugins = ctx.meta.get(MDSVEX_REMARK_PLUGINS_META_KEY);
+      const remarkPlugins = [
+        ...(Array.isArray(configuredRemarkPlugins) ? configuredRemarkPlugins : []),
+        ...(BASE_REMARK_PLUGINS ?? []),
+      ] as MdsvexOptions["remarkPlugins"];
       const noteFiles = ctx.files.filter((file) =>
         file.extension && [".md", ".mdx", ".svx"].includes(file.extension),
       );
@@ -142,7 +150,7 @@ export const emitArtifacts = definePlugin(() => ({
         noteFiles.map(async (file) => {
           const key = `pages/${file.slug}.svelte`;
           const path = join(artifactsRoot, key);
-          const contents = await compileNoteComponent(file);
+          const contents = await compileNoteComponent(file, remarkPlugins);
 
           const artifact: Artifact = {
             key,

--- a/packages/plugins/src/filter-unpublished.ts
+++ b/packages/plugins/src/filter-unpublished.ts
@@ -1,12 +1,10 @@
 /**
  * core:filter-unpublished — remove unpublished files from the pipeline.
  *
- * Published semantics (from plan):
- *   - published missing/null/undefined => published
- *   - published: true => published
- *   - published: <datetime string> => published
- *   - published: false => unpublished
- *   - published: "" => unpublished
+ * Publication modes:
+ *   - opt-out (default): missing/null => published
+ *   - explicit: only true or another truthy value => published
+ * In both modes false and an empty string are unpublished.
  *
  * Runs `post` relative to parseFrontmatter to ensure frontmatter is available.
  */
@@ -19,13 +17,15 @@ export const filterUnpublished = definePlugin(() => ({
   filterUnpublished: {
     run(ctx) {
       const publishedField = ctx.config.frontmatter.publishedField;
+      const explicitPublication = ctx.config.frontmatter.publicationMode === "explicit";
 
       ctx.files = ctx.files.filter((file) => {
-        if (!publishedField || !file.frontmatter) return true;
+        if (!publishedField) return true;
+        if (!file.frontmatter) return !explicitPublication;
 
         const value = file.frontmatter[publishedField];
 
-        if (value === undefined || value === null) return true;
+        if (value === undefined || value === null) return !explicitPublication;
         if (value === true) return true;
         if (value === false) return false;
         if (value === "") return false;

--- a/packages/plugins/src/transform-gfm.ts
+++ b/packages/plugins/src/transform-gfm.ts
@@ -1,18 +1,26 @@
 /**
- * core:transform-gfm — GitHub Flavored Markdown transforms.
+ * core:transform-gfm — register GitHub Flavored Markdown compilation.
  *
- * Handles tables, task lists, strikethrough, and other GFM features.
- * MVP: passes through unchanged.
+ * GFM is an mdsvex/remark concern rather than a safe text rewrite. This stage
+ * contributes remark-gfm to the compiler options consumed by emit-artifacts.
  */
 
 import { definePlugin } from "@svartz/core";
+import remarkGfm from "remark-gfm";
+
+export const MDSVEX_REMARK_PLUGINS_META_KEY = "svartz:mdsvex:remarkPlugins" as const;
 
 export const transformGfm = definePlugin(() => ({
   id: "core:transform-gfm",
 
   transformGfm: {
-    run(_ctx) {
-      // MVP stub — GFM transforms implemented incrementally
+    run(ctx) {
+      const configured = ctx.meta.get(MDSVEX_REMARK_PLUGINS_META_KEY);
+      const remarkPlugins = Array.isArray(configured) ? configured : [];
+
+      if (!remarkPlugins.includes(remarkGfm)) {
+        ctx.meta.set(MDSVEX_REMARK_PLUGINS_META_KEY, [...remarkPlugins, remarkGfm]);
+      }
     },
     options: { fatal: true },
   },

--- a/packages/plugins/src/transform-ofm.ts
+++ b/packages/plugins/src/transform-ofm.ts
@@ -9,24 +9,91 @@ import { definePlugin } from "@svartz/core";
 
 const HTML_COMMENT_REGEX = /<!--[\s\S]*?-->/g;
 const OBSIDIAN_COMMENT_REGEX = /%%([\s\S]*?)%%/g;
-const COMMENT_PLACEHOLDER_PREFIX = "__SVARTZ_HTML_COMMENT_";
+const PROTECTED_SEGMENT_PREFIX = "__SVARTZ_PROTECTED_SEGMENT_";
 
-function transformCallouts(markdown: string): string {
+interface SegmentStore {
+  readonly prefix: string;
+  readonly segments: string[];
+}
+
+function createSegmentStore(markdown: string): SegmentStore {
+  let prefix = PROTECTED_SEGMENT_PREFIX;
+  while (markdown.includes(prefix)) prefix = `_${prefix}`;
+  return { prefix, segments: [] };
+}
+
+function protectSegment(store: SegmentStore, segment: string): string {
+  const placeholder = `${store.prefix}${store.segments.length}__`;
+  store.segments.push(segment);
+  return placeholder;
+}
+
+function stripBlockquotePrefix(line: string): string {
+  return line.replace(/^[ \t]*(?:>[ \t]?)+/, "");
+}
+
+function isIndentedCode(line: string): boolean {
+  if (/^(?: {4}|\t)/.test(line)) return true;
+  const withoutBlockquote = stripBlockquotePrefix(line);
+  return withoutBlockquote !== line && /^(?: {4}|\t)/.test(withoutBlockquote);
+}
+
+function protectCode(markdown: string, store: SegmentStore): string {
   const lines = markdown.split("\n");
-  return lines
-    .map((line) => {
-      const match = /^>\s*\[!([^\]\s]+)\]([+-])?\s*(.*)$/.exec(line);
-      if (!match) return line;
+  const protectedLines: string[] = [];
+  let fence: { readonly marker: "`" | "~"; readonly length: number } | undefined;
+  let fencedLines: string[] = [];
 
-      const [, rawType = "note", , title] = match;
-      const renderedTitle =
-        title && title.length > 0
-          ? title
-          : rawType.replace(/[-_]/g, " ").replace(/\b\w/g, (char) => char.toUpperCase());
+  for (const line of lines) {
+    if (!fence) {
+      if (isIndentedCode(line)) {
+        protectedLines.push(protectSegment(store, line));
+        continue;
+      }
 
-      return `> **${renderedTitle}**`;
-    })
-    .join("\n");
+      const openingFence = /^(`{3,}|~{3,})/.exec(stripBlockquotePrefix(line));
+      if (!openingFence) {
+        protectedLines.push(line);
+        continue;
+      }
+
+      const token = openingFence[1]!;
+      fence = {
+        marker: token[0] as "`" | "~",
+        length: token.length,
+      };
+      fencedLines = [line];
+      continue;
+    }
+
+    fencedLines.push(line);
+    const closingFence = new RegExp(
+      `^${fence.marker === "`" ? "`" : "~"}{${fence.length},}\\s*$`,
+    );
+    if (!closingFence.test(stripBlockquotePrefix(line))) continue;
+
+    protectedLines.push(protectSegment(store, fencedLines.join("\n")));
+    fence = undefined;
+    fencedLines = [];
+  }
+
+  if (fencedLines.length > 0) {
+    protectedLines.push(protectSegment(store, fencedLines.join("\n")));
+  }
+
+  return protectedLines
+    .join("\n")
+    .replace(/(`+)(?!`)([\s\S]*?)\1(?!`)/g, (codeSpan) =>
+      protectSegment(store, codeSpan),
+    );
+}
+
+function restoreSegments(markdown: string, store: SegmentStore): string {
+  return store.segments.reduce(
+    (restoredMarkdown, segment, index) =>
+      restoredMarkdown.replace(`${store.prefix}${index}__`, segment),
+    markdown,
+  );
 }
 
 function normalizeComments(markdown: string): string {
@@ -36,42 +103,47 @@ function normalizeComments(markdown: string): string {
   );
 }
 
-function protectHtmlComments(markdown: string): {
-  sanitizedMarkdown: string;
-  comments: string[];
-} {
-  const comments: string[] = [];
-  const sanitizedMarkdown = markdown.replace(HTML_COMMENT_REGEX, (comment) => {
-    const placeholder = `${COMMENT_PLACEHOLDER_PREFIX}${comments.length}__`;
-    comments.push(comment);
-    return placeholder;
-  });
-
-  return { sanitizedMarkdown, comments };
+function protectHtmlComments(markdown: string, store: SegmentStore): string {
+  return markdown.replace(HTML_COMMENT_REGEX, (comment) => protectSegment(store, comment));
 }
 
-function restoreHtmlComments(markdown: string, comments: readonly string[]): string {
-  return comments.reduce(
-    (restoredMarkdown, comment, index) =>
-      restoredMarkdown.replace(`${COMMENT_PLACEHOLDER_PREFIX}${index}__`, comment),
-    markdown,
-  );
+function titleCaseCalloutType(type: string): string {
+  return type
+    .replace(/[-_]/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function normalizeCalloutType(type: string): string {
+  return type.toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+}
+
+function transformCallouts(markdown: string): string {
+  return markdown
+    .split("\n")
+    .map((line) => {
+      const match = /^([ \t]*(?:>[ \t]*)+)\[!([^\]\s]+)\]([+-])?\s*(.*)$/.exec(line);
+      if (!match) return line;
+
+      const [, quotePrefix, rawType = "note", fold, customTitle] = match;
+      const type = normalizeCalloutType(rawType);
+      const title = customTitle || titleCaseCalloutType(rawType);
+      const foldState = fold === "+" ? "open" : fold === "-" ? "closed" : undefined;
+      const foldAttribute = foldState ? ` data-callout-fold="${foldState}"` : "";
+
+      return `${quotePrefix}<span class="callout-marker" data-callout="${type}"${foldAttribute} aria-hidden="true"></span> **${title}**`;
+    })
+    .join("\n");
+}
+
+function transformHighlights(markdown: string): string {
+  return markdown.replace(/==([^=\n]+)==/g, "<mark>$1</mark>");
 }
 
 function sanitizeMarkdownForSvelte(markdown: string): string {
-  const { sanitizedMarkdown, comments } = protectHtmlComments(markdown);
-  const lines = sanitizedMarkdown.split("\n");
-  let inCodeFence = false;
-
-  const sanitized = lines
+  return markdown
+    .split("\n")
     .map((line) => {
       const trimmed = line.trim();
-      if (/^(```|~~~)/.test(trimmed)) {
-        inCodeFence = !inCodeFence;
-        return line;
-      }
-
-      if (inCodeFence) return line;
       if (/^#{1,6}\s*$/.test(trimmed)) return "";
 
       return line
@@ -81,13 +153,22 @@ function sanitizeMarkdownForSvelte(markdown: string): string {
           match.replace(/</g, "&lt;").replace(/>/g, "&gt;"),
         )
         .replace(/<<(?=\s)/g, "&lt;&lt;")
-        .replace(/(?<=\s)>>/g, "&gt;&gt;")
         .replace(/<(?=[^A-Za-z!/])/g, "&lt;")
-        .replace(/(?<![A-Za-z0-9"'\/=])>/g, "&gt;");
+        .replace(/&lt;([^<>\n]*)>/g, "&lt;$1&gt;");
     })
     .join("\n");
+}
 
-  return restoreHtmlComments(sanitized, comments);
+function transformMarkdown(markdown: string): string {
+  const store = createSegmentStore(markdown);
+  const protectedCode = protectCode(markdown, store);
+  const normalizedComments = normalizeComments(protectedCode);
+  const protectedComments = protectHtmlComments(normalizedComments, store);
+  const transformed = sanitizeMarkdownForSvelte(
+    transformCallouts(transformHighlights(protectedComments)),
+  );
+
+  return restoreSegments(transformed, store);
 }
 
 export const transformOfm = definePlugin(() => ({
@@ -98,13 +179,7 @@ export const transformOfm = definePlugin(() => ({
       for (const file of ctx.files) {
         if (!file.extension || ![".md", ".mdx", ".svx"].includes(file.extension)) continue;
 
-        file.content = sanitizeMarkdownForSvelte(
-          transformCallouts(
-            normalizeComments(
-              file.content.replace(/==([^=]+)==/g, "<mark>$1</mark>"),
-            ),
-          ),
-        );
+        file.content = transformMarkdown(file.content);
       }
     },
     options: { fatal: true },

--- a/packages/plugins/tests/emit-artifacts.test.ts
+++ b/packages/plugins/tests/emit-artifacts.test.ts
@@ -4,6 +4,8 @@ import { tmpdir } from "node:os";
 import { afterEach, describe, expect, it } from "vitest";
 import type { Index, PluginContext, ProcessedFile } from "@svartz/core";
 import { emitArtifacts } from "../src/emit-artifacts";
+import { transformGfm } from "../src/transform-gfm";
+import { transformOfm } from "../src/transform-ofm";
 
 const tempDirs: string[] = [];
 
@@ -58,7 +60,14 @@ describe("core:emit-artifacts", () => {
           path: "guides/intro.md",
           slug: "guides/intro",
           extension: ".md",
-          content: "# Intro\n\nWelcome to Svartz.",
+          content: [
+            "# Intro",
+            "",
+            "Welcome to Svartz. ~~Outdated guidance.~~",
+            "",
+            "> [!note] Launch note",
+            "> Keep the static output readable.",
+          ].join("\n"),
           frontmatter: { title: "Intro" },
         },
       ],
@@ -90,6 +99,8 @@ describe("core:emit-artifacts", () => {
       outDir,
     );
 
+    transformOfm().transformOfm!.run(ctx);
+    transformGfm().transformGfm!.run(ctx);
     await emitArtifacts().emitArtifacts!.run(ctx);
 
     const artifactsRoot = resolve(outDir, "..", "artifacts");
@@ -106,6 +117,9 @@ describe("core:emit-artifacts", () => {
 
     expect(pageModule).toContain("export const svartz");
     expect(pageModule).toContain("Welcome to Svartz.");
+    expect(pageModule).toContain("<del>Outdated guidance.</del>");
+    expect(pageModule).toContain("<blockquote>");
+    expect(pageModule).toContain('data-callout="note"');
     expect(indexModule).toContain("export const index =");
     expect(indexModule).toContain("export const graph = index.graph;");
   });

--- a/packages/plugins/tests/filter-unpublished.test.ts
+++ b/packages/plugins/tests/filter-unpublished.test.ts
@@ -5,6 +5,7 @@ import type { PluginContext, ProcessedFile } from "@svartz/core";
 const makeCtx = (
   files: ProcessedFile[],
   publishedField = "published",
+  publicationMode: "opt-out" | "explicit" = "opt-out",
 ): PluginContext =>
   ({
     config: {
@@ -24,6 +25,7 @@ const makeCtx = (
         createdAtField: "created_at",
         updatedAtField: "updated_at",
         publishedField,
+        publicationMode,
       },
       target: { type: "static" },
       plugins: [],
@@ -63,6 +65,12 @@ describe("core:filter-unpublished", () => {
     const ctx = makeCtx([makeFile("a")]);
     plugin.filterUnpublished!.run(ctx);
     expect(ctx.files).toHaveLength(1);
+  });
+
+  it("removes files without publication metadata in explicit mode", () => {
+    const ctx = makeCtx([makeFile("draft"), makeFile("published", true)], "published", "explicit");
+    plugin.filterUnpublished!.run(ctx);
+    expect(ctx.files.map((file) => file.slug)).toEqual(["published"]);
   });
 
   it("keeps files with published: null", () => {

--- a/packages/plugins/tests/transform-gfm.test.ts
+++ b/packages/plugins/tests/transform-gfm.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import type { PluginContext } from "@svartz/core";
+import remarkGfm from "remark-gfm";
+import { transformGfm } from "../src/transform-gfm";
+
+function makeCtx(): PluginContext {
+  return {
+    config: {
+      version: "0.0.1",
+      id: "test",
+      path: "/vault",
+      outDir: "/out",
+      include: [],
+      exclude: [],
+      linkResolution: "closest",
+      theme: { base: "default" },
+      frontmatter: {
+        titleField: "title",
+        descriptionField: "description",
+        tagsField: "tags",
+        aliasesField: "aliases",
+        createdAtField: "created_at",
+        updatedAtField: "updated_at",
+        publishedField: "published",
+      },
+      target: { type: "static" },
+      plugins: [],
+    },
+    files: [],
+    artifacts: new Map(),
+    meta: new Map(),
+  } as PluginContext;
+}
+
+describe("transformGfm", () => {
+  it("registers remark-gfm for artifact compilation", () => {
+    const ctx = makeCtx();
+
+    transformGfm().transformGfm!.run(ctx);
+
+    expect(ctx.meta.get("svartz:mdsvex:remarkPlugins")).toEqual([remarkGfm]);
+  });
+});

--- a/packages/plugins/tests/transform-ofm.test.ts
+++ b/packages/plugins/tests/transform-ofm.test.ts
@@ -72,4 +72,124 @@ describe("transformOfm", () => {
 
     expect(ctx.files[0]!.content).toContain("<!-- hidden note -->");
   });
+
+  it("preserves ordinary markdown blockquotes", () => {
+    const ctx = makeCtx("> Quoted text\n> continues here\n");
+
+    transformOfm().transformOfm!.run(ctx);
+
+    expect(ctx.files[0]!.content).toBe("> Quoted text\n> continues here\n");
+  });
+
+  it("preserves callout type and closed fold state without breaking the blockquote", () => {
+    const ctx = makeCtx("> [!warning]- Read this first\n> Callout body\n");
+
+    transformOfm().transformOfm!.run(ctx);
+
+    expect(ctx.files[0]!.content).toContain(
+      '> <span class="callout-marker" data-callout="warning" data-callout-fold="closed" aria-hidden="true"></span> **Read this first**',
+    );
+    expect(ctx.files[0]!.content).toContain("> Callout body");
+  });
+
+  it("uses the callout type as the default title and preserves open fold state", () => {
+    const ctx = makeCtx("> [!important]+\n> Callout body\n");
+
+    transformOfm().transformOfm!.run(ctx);
+
+    expect(ctx.files[0]!.content).toContain(
+      '> <span class="callout-marker" data-callout="important" data-callout-fold="open" aria-hidden="true"></span> **Important**',
+    );
+  });
+
+  it("does not transform OFM syntax inside fenced or inline code", () => {
+    const ctx = makeCtx(
+      [
+        "outside ==highlight== and %% hidden %%",
+        "",
+        "```md",
+        "literal ==highlight==",
+        "> [!note] literal callout",
+        "%% literal comment %%",
+        "```",
+        "",
+        "inline `==highlight== %% comment %%` remains literal",
+      ].join("\n"),
+    );
+
+    transformOfm().transformOfm!.run(ctx);
+
+    expect(ctx.files[0]!.content).toContain(
+      "outside <mark>highlight</mark> and <!-- hidden -->",
+    );
+    expect(ctx.files[0]!.content).toContain(
+      [
+        "```md",
+        "literal ==highlight==",
+        "> [!note] literal callout",
+        "%% literal comment %%",
+        "```",
+      ].join("\n"),
+    );
+    expect(ctx.files[0]!.content).toContain(
+      "inline `==highlight== %% comment %%` remains literal",
+    );
+  });
+
+  it("restores interleaved code and comments without placeholder collisions", () => {
+    const ctx = makeCtx(
+      "`code` before <!-- hidden --> after __SVARTZ_PROTECTED_SEGMENT_0__\n",
+    );
+
+    transformOfm().transformOfm!.run(ctx);
+
+    expect(ctx.files[0]!.content).toBe(
+      "`code` before <!-- hidden --> after __SVARTZ_PROTECTED_SEGMENT_0__\n",
+    );
+  });
+
+  it("does not transform indented or blockquoted fenced code", () => {
+    const ctx = makeCtx(
+      [
+        "    ==indented== %% literal %%",
+        "",
+        "  ```md",
+        "  ==indented fence== %% literal %%",
+        "  ```",
+        "",
+        "> ~~~md",
+        "> ==quoted fence== %% literal %%",
+        "> ~~~",
+      ].join("\n"),
+    );
+
+    transformOfm().transformOfm!.run(ctx);
+
+    expect(ctx.files[0]!.content).toContain("    ==indented== %% literal %%");
+    expect(ctx.files[0]!.content).toContain(
+      [
+        "  ```md",
+        "  ==indented fence== %% literal %%",
+        "  ```",
+      ].join("\n"),
+    );
+    expect(ctx.files[0]!.content).toContain(
+      [
+        "> ~~~md",
+        "> ==quoted fence== %% literal %%",
+        "> ~~~",
+      ].join("\n"),
+    );
+  });
+
+  it("preserves nested blockquote prefixes for nested callouts", () => {
+    const ctx = makeCtx("> > [!warning]- Nested warning\n> > Nested body\n");
+
+    transformOfm().transformOfm!.run(ctx);
+
+    expect(ctx.files[0]!.content).toContain(
+      '> > <span class="callout-marker" data-callout="warning" data-callout-fold="closed" aria-hidden="true"></span> **Nested warning**',
+    );
+    expect(ctx.files[0]!.content).toContain("> > Nested body");
+  });
 });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build && pnpm run prepack",
+		"build": "vite build && svelte-kit sync && svelte-package && publint",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"prepack": "svelte-kit sync && svelte-package && publint",

--- a/packages/ui/src/lib/NoteHeader.svelte
+++ b/packages/ui/src/lib/NoteHeader.svelte
@@ -2,18 +2,24 @@
 	type Entry = {
 		title: string;
 		description?: string;
-		createdAt?: Date;
-		modifiedAt?: Date;
+		createdAt?: Date | string;
+		modifiedAt?: Date | string;
 		tags?: readonly string[];
 		wordCount?: number;
 	};
 
 	let { entry }: { entry?: Entry } = $props();
 
-	function formatDate(value: Date | undefined): string | undefined {
-		return value
-			? value.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' })
-			: undefined;
+	function formatDate(value: Date | string | undefined): string | undefined {
+		if (!value) return undefined;
+		const date = value instanceof Date ? value : new Date(value);
+		if (Number.isNaN(date.getTime())) return undefined;
+		return new Intl.DateTimeFormat('en', {
+			year: 'numeric',
+			month: 'short',
+			day: 'numeric',
+			timeZone: 'UTC'
+		}).format(date);
 	}
 
 	const createdAt = $derived(formatDate(entry?.createdAt));

--- a/packages/ui/src/lib/SearchBox.svelte
+++ b/packages/ui/src/lib/SearchBox.svelte
@@ -41,6 +41,8 @@
 	let query = $state('');
 	let selectedIndex = $state(-1);
 	let inputEl = $state<HTMLInputElement | undefined>();
+	let triggerEl = $state<HTMLButtonElement | undefined>();
+	let dialogEl = $state<HTMLDivElement | undefined>();
 
 	const results = $derived(
 		query.trim().length < 2 || !engine
@@ -58,6 +60,7 @@
 		open = false;
 		query = '';
 		selectedIndex = -1;
+		requestAnimationFrame(() => triggerEl?.focus());
 	}
 
 	function slugToHref(slug: string) {
@@ -105,6 +108,21 @@
 			e.preventDefault();
 			const result = results[selectedIndex];
 			if (result) navigate(result);
+		} else if (e.key === 'Tab' && dialogEl) {
+			const focusable = [
+				...dialogEl.querySelectorAll<HTMLElement>(
+					'button, input, a[href], [tabindex]:not([tabindex="-1"])'
+				)
+			];
+			const first = focusable[0];
+			const last = focusable.at(-1);
+			if (e.shiftKey && document.activeElement === first) {
+				e.preventDefault();
+				last?.focus();
+			} else if (!e.shiftKey && document.activeElement === last) {
+				e.preventDefault();
+				first?.focus();
+			}
 		}
 	}
 
@@ -115,6 +133,7 @@
 
 <!-- Sidebar trigger -->
 <button
+	bind:this={triggerEl}
 	type="button"
 	onclick={openModal}
 	aria-label="Open search (Ctrl+K)"
@@ -143,10 +162,7 @@
 
 <!-- Modal -->
 {#if open}
-	<div
-		class="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
-		aria-hidden="true"
-	>
+	<div class="fixed inset-0 z-50 flex items-start justify-center px-3 pt-[15vh]">
 		<!-- Backdrop (click to close) -->
 		<button
 			type="button"
@@ -157,6 +173,7 @@
 
 		<!-- Dialog -->
 		<div
+			bind:this={dialogEl}
 			role="dialog"
 			aria-modal="true"
 			aria-label="Search"

--- a/packages/ui/src/lib/TableOfContents.svelte
+++ b/packages/ui/src/lib/TableOfContents.svelte
@@ -99,35 +99,37 @@
 				{@const hasChildren = section.children.length > 0}
 				<li>
 					{#if hasChildren}
-						<button
-							type="button"
-							onclick={() => toggleSection(section.slug)}
-							aria-expanded={isExpanded}
-							class="flex w-full items-center gap-1.5 rounded px-0 py-0.5 text-left text-xs font-medium text-zinc-700 transition-colors hover:text-zinc-900 dark:text-zinc-300 dark:hover:text-zinc-100"
-						>
-							<svg
-								class="size-3 shrink-0 transition-transform {isExpanded ? 'rotate-90' : ''}"
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 20 20"
-								fill="currentColor"
-								aria-hidden="true"
+						<div class="flex min-h-10 items-center gap-1">
+							<button
+								type="button"
+								onclick={() => toggleSection(section.slug)}
+								aria-expanded={isExpanded}
+								aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${section.text}`}
+								class="grid size-9 shrink-0 place-items-center rounded text-zinc-500 transition-colors hover:bg-zinc-100 hover:text-zinc-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-600 dark:hover:bg-zinc-800 dark:hover:text-zinc-100"
 							>
-								<path
-									fill-rule="evenodd"
-									d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
-									clip-rule="evenodd"
-								/>
-							</svg>
+								<svg
+									class="size-3 shrink-0 transition-transform {isExpanded ? 'rotate-90' : ''}"
+									xmlns="http://www.w3.org/2000/svg"
+									viewBox="0 0 20 20"
+									fill="currentColor"
+									aria-hidden="true"
+								>
+									<path
+										fill-rule="evenodd"
+										d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+										clip-rule="evenodd"
+									/>
+								</svg>
+							</button>
 							<a
 								href="#{section.slug}"
-								class="{activeSlug === section.slug
+								class="min-w-0 flex-1 py-2 text-xs font-medium {activeSlug === section.slug
 									? 'text-zinc-900 dark:text-zinc-100'
-									: 'text-zinc-600 dark:text-zinc-400'} leading-relaxed transition-colors hover:text-zinc-900 dark:hover:text-zinc-100"
-								onclick={(e) => e.stopPropagation()}
+									: 'text-zinc-600 dark:text-zinc-400'} leading-relaxed transition-colors hover:text-zinc-900 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-600 dark:hover:text-zinc-100"
 							>
 								{section.text}
 							</a>
-						</button>
+						</div>
 						{#if isExpanded}
 							<ul class="ml-3 border-l border-zinc-200 pl-2 dark:border-zinc-700">
 								{#each section.children as child (child.slug)}

--- a/packages/vite/src/artifacts.ts
+++ b/packages/vite/src/artifacts.ts
@@ -56,30 +56,41 @@ function createArtifactsVirtualModuleSource(
     noteSlug: artifact.noteSlug,
   }));
 
-  const loaders = artifacts
-    .filter((artifact) => artifact.type === "svelte")
+  const svelteArtifacts = artifacts.filter((artifact) => artifact.type === "svelte");
+  const noteImports = svelteArtifacts
     .map(
-      (artifact) =>
-        `  ${JSON.stringify(artifact.key)}: () => import(${JSON.stringify(artifact.path)}),`,
+      (artifact, index) =>
+        `import * as noteArtifact${index} from ${JSON.stringify(artifact.path)};`,
+    )
+    .join("\n");
+  const noteModules = svelteArtifacts
+    .map(
+      (artifact, index) =>
+        `  ${JSON.stringify(artifact.key)}: noteArtifact${index},`,
     )
     .join("\n");
 
   return [
     `import { index, graph, backlinks, search, tags, folders, routes, assets } from ${JSON.stringify(indexModulePath)};`,
     `import { searchDocuments, searchIndex } from ${JSON.stringify(searchModulePath)};`,
+    noteImports,
     "",
     `export const artifacts = new Map(${JSON.stringify(records)}.map((record) => [record.key, record]));`,
     "",
-    "const noteArtifactLoaders = {",
-    loaders,
+    "const noteArtifactModules = {",
+    noteModules,
     "};",
     "",
-    "export async function loadNoteArtifact(key) {",
-    "  const loader = noteArtifactLoaders[key];",
-    "  if (!loader) {",
+    "export function hasNoteArtifact(key) {",
+    "  return Object.hasOwn(noteArtifactModules, key);",
+    "}",
+    "",
+    "export function getNoteArtifact(key) {",
+    "  const artifact = noteArtifactModules[key];",
+    "  if (!artifact) {",
     '    throw new Error(`[svartz:vite] note artifact "${key}" is not available`);',
     "  }",
-    "  return loader();",
+    "  return artifact;",
     "}",
     "",
     `export const themeConfig = ${JSON.stringify(themeConfig)};`,

--- a/packages/vite/src/artifacts.ts
+++ b/packages/vite/src/artifacts.ts
@@ -48,6 +48,7 @@ function createArtifactsVirtualModuleSource(
   indexModulePath: string,
   searchModulePath: string,
   themeConfig: Record<string, unknown> = {},
+  siteConfig: ResolvedConfig["site"] = { title: "Svartz" },
 ): string {
   const records = artifacts.map((artifact) => ({
     key: artifact.key,
@@ -94,6 +95,7 @@ function createArtifactsVirtualModuleSource(
     "}",
     "",
     `export const themeConfig = ${JSON.stringify(themeConfig)};`,
+    `export const siteConfig = ${JSON.stringify(siteConfig)};`,
     "",
     "export { index, graph, backlinks, search, tags, folders, routes, assets, searchDocuments, searchIndex };",
   ].join("\n");

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -247,7 +247,7 @@ function svartz(options: SvartzVitePluginOptions): Plugin {
     },
     configResolved(resolved) {
       context = createSvartzViteContext(options, resolved);
-      themeModuleId = resolveThemeModuleId(context.config);
+      themeModuleId = resolveThemeRuntimeImportId(context.config, context.root);
     },
     async buildStart() {
       await executePipeline();

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -171,6 +171,7 @@ function svartz(options: SvartzVitePluginOptions): Plugin {
               getGeneratedIndexModulePath(context.config),
               getGeneratedSearchModulePath(context.config),
               extractThemeConfig(context.config.theme),
+              context.config.site,
             ),
           ),
         ],
@@ -306,6 +307,7 @@ function svartz(options: SvartzVitePluginOptions): Plugin {
           getGeneratedIndexModulePath(context.config),
           getGeneratedSearchModulePath(context.config),
           extractThemeConfig(context.config.theme),
+          context.config.site,
         );
       }
 

--- a/packages/vite/src/theme-resolver.ts
+++ b/packages/vite/src/theme-resolver.ts
@@ -10,6 +10,7 @@ type ThemeModule = Record<string, unknown> & {
 };
 
 const BUILTIN_THEME_MODULE_ID = "@svartz/theme-minimal";
+const BUILTIN_THEME_RUNTIME_MODULE_ID = `${BUILTIN_THEME_MODULE_ID}/runtime`;
 
 function resolveThemeModuleId(config: ResolvedConfig): string {
   return config.theme.base;
@@ -38,6 +39,17 @@ function resolvePackageRootFromEntry(resolvedEntryPath: string): string | undefi
 }
 
 function resolveThemeRuntimeImportId(
+  config: ResolvedConfig,
+  resolveFromDirectory = process.cwd(),
+): string {
+  const themeModuleId = resolveThemeModuleId(config);
+  const runtimeModuleId =
+    themeModuleId === BUILTIN_THEME_MODULE_ID ? BUILTIN_THEME_RUNTIME_MODULE_ID : themeModuleId;
+  const requireFromDirectory = createRequireFromDirectory(resolveFromDirectory);
+  return pathToFileURL(requireFromDirectory.resolve(runtimeModuleId)).href;
+}
+
+function resolveThemeBuildImportId(
   config: ResolvedConfig,
   resolveFromDirectory = process.cwd(),
 ): string {
@@ -82,7 +94,7 @@ async function loadThemeModule(
   resolveFromDirectory = process.cwd(),
 ): Promise<SvartzTheme> {
   const themeModule = (await loader(
-    resolveThemeRuntimeImportId(config, resolveFromDirectory),
+    resolveThemeBuildImportId(config, resolveFromDirectory),
   )) as ThemeModule;
   const { base: _base, ...themeConfig } = config.theme;
   return resolveThemeExport(themeModule, themeConfig);

--- a/packages/vite/src/virtual-modules.ts
+++ b/packages/vite/src/virtual-modules.ts
@@ -41,6 +41,7 @@ const ARTIFACTS_PLACEHOLDER_SOURCE = [
   'export const searchDocuments = [];',
   'export const searchIndex = { documentCount: 0, nextId: 0, storedFields: {}, fieldIds: {}, fieldLength: {}, averageFieldLength: {}, index: [], serializationVersion: 2 };',
   'export const themeConfig = {};',
+  'export const siteConfig = { title: "Svartz" };',
 ].join("\n");
 
 type SvartzVirtualModuleId =

--- a/packages/vite/src/virtual-modules.ts
+++ b/packages/vite/src/virtual-modules.ts
@@ -23,7 +23,11 @@ const THEME_PLACEHOLDER_SOURCE = [
 
 const ARTIFACTS_PLACEHOLDER_SOURCE = [
   'export const artifacts = new Map();',
-  'export async function loadNoteArtifact(key) {',
+  'export function hasNoteArtifact() {',
+  '  return false;',
+  '}',
+  '',
+  'export function getNoteArtifact(key) {',
   '  throw new Error(`[svartz:vite] note artifact "${key}" is not available yet`);',
   '}',
   'export const index = { version: "0.0.0", entries: [], graph: {}, backlinks: {}, search: [], tags: [], folders: [], routes: { notes: [], tags: [], folders: [], feed: [], all: [] }, assets: [] };',

--- a/packages/vite/tests/artifacts.test.ts
+++ b/packages/vite/tests/artifacts.test.ts
@@ -56,7 +56,7 @@ describe("@svartz/vite artifact helpers", () => {
     );
   });
 
-  it("builds a lazy artifact bridge source with eager index re-exports", () => {
+  it("builds an eager artifact bridge source for SSR", () => {
     const artifacts: Artifact[] = [
       {
         key: "pages/guides/intro.svelte",
@@ -87,7 +87,16 @@ describe("@svartz/vite artifact helpers", () => {
     expect(source).toContain(
       'import { searchDocuments, searchIndex } from "/workspace/.svartz/vaults/docs/artifacts/search.ts";',
     );
-    expect(source).toContain('"pages/guides/intro.svelte": () => import("/workspace/.svartz/vaults/docs/artifacts/pages/guides/intro.svelte")');
+    expect(source).toContain(
+      'import * as noteArtifact0 from "/workspace/.svartz/vaults/docs/artifacts/pages/guides/intro.svelte";',
+    );
+    expect(source).toContain(
+      '"pages/guides/intro.svelte": noteArtifact0',
+    );
+    expect(source).toContain("export function hasNoteArtifact(key)");
+    expect(source).toContain("export function getNoteArtifact(key)");
+    expect(source).not.toContain("() => import(");
+    expect(source).not.toContain("async function getNoteArtifact");
     expect(source).toContain("export const artifacts = new Map");
   });
 });

--- a/packages/vite/tests/artifacts.test.ts
+++ b/packages/vite/tests/artifacts.test.ts
@@ -93,6 +93,7 @@ describe("@svartz/vite artifact helpers", () => {
     expect(source).toContain(
       '"pages/guides/intro.svelte": noteArtifact0',
     );
+    expect(source).toContain('export const siteConfig = {"title":"Svartz"};');
     expect(source).toContain("export function hasNoteArtifact(key)");
     expect(source).toContain("export function getNoteArtifact(key)");
     expect(source).not.toContain("() => import(");

--- a/packages/vite/tests/index.test.ts
+++ b/packages/vite/tests/index.test.ts
@@ -146,6 +146,7 @@ describe("@svartz/vite plugin", () => {
     expect(loadThemeModuleMock).toHaveBeenCalledWith(
       expect.any(Function),
       testConfig,
+      process.cwd(),
     );
     expect(resolveRuntimePluginsMock).toHaveBeenCalled();
     expect(runStagesMock).toHaveBeenCalled();

--- a/packages/vite/tests/theme-resolver.test.ts
+++ b/packages/vite/tests/theme-resolver.test.ts
@@ -72,10 +72,11 @@ describe("@svartz/vite theme bridge", () => {
     expect(source).toContain("return resolveThemeRouteToArtifactKey(routes, input);");
   });
 
-  it("keeps the built-in fallback theme import rooted in @svartz/vite", () => {
-    expect(resolveThemeRuntimeImportId(createConfig(BUILTIN_THEME_MODULE_ID))).toBe(
-      BUILTIN_THEME_MODULE_ID,
-    );
+  it("uses the built-in theme's SSR runtime entry", () => {
+    const runtimeImportId = resolveThemeRuntimeImportId(createConfig(BUILTIN_THEME_MODULE_ID));
+
+    expect(runtimeImportId.startsWith("file://")).toBe(true);
+    expect(runtimeImportId.endsWith("/dist/runtime.js")).toBe(true);
   });
 
   it("resolves non-default themes from the provided app root", async () => {

--- a/packages/vite/types/virtual-modules.d.ts
+++ b/packages/vite/types/virtual-modules.d.ts
@@ -30,9 +30,10 @@ declare module "virtual:svartz/artifacts" {
   }
 
   export const artifacts: ReadonlyMap<string, RuntimeArtifactRecord>;
-  export function loadNoteArtifact(
+  export function hasNoteArtifact(key: string): boolean;
+  export function getNoteArtifact(
     key: string,
-  ): Promise<{ default: unknown }>;
+  ): { default: unknown };
   export const index: Index;
   export const graph: Graph;
   export const backlinks: Index["backlinks"];

--- a/packages/vite/types/virtual-modules.d.ts
+++ b/packages/vite/types/virtual-modules.d.ts
@@ -38,4 +38,12 @@ declare module "virtual:svartz/artifacts" {
   export const graph: Graph;
   export const backlinks: Index["backlinks"];
   export const search: Index["entries"];
+  export const themeConfig: Readonly<Record<string, unknown>>;
+  export const siteConfig: Readonly<{
+    title: string;
+    description?: string;
+    url?: string;
+    author?: string;
+    image?: string;
+  }>;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.2
-        version: 2.0.2(eslint@9.39.3(jiti@2.6.1))
+        version: 2.0.2(eslint@9.39.3(jiti@2.7.0))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.3
@@ -37,22 +37,22 @@ importers:
         version: 2.13.1
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
-        version: 7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
+        version: 7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
       '@sveltejs/adapter-cloudflare':
         specifier: ^7.2.8
-        version: 7.2.8(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(wrangler@4.69.0)
+        version: 7.2.8(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(wrangler@4.69.0)
       '@sveltejs/adapter-node':
         specifier: ^5.5.4
-        version: 5.5.4(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
+        version: 5.5.4(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
       '@sveltejs/adapter-static':
         specifier: ^3.0.10
-        version: 3.0.10(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
+        version: 3.0.10(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
       '@sveltejs/kit':
         specifier: ^2.50.2
-        version: 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.1)
@@ -61,25 +61,25 @@ importers:
         version: 0.5.19(tailwindcss@4.2.1)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@types/node':
         specifier: ^24.11.0
         version: 24.11.0
       '@vitest/browser-playwright':
         specifier: ^4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.3(jiti@2.6.1)
+        version: 9.39.3(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.3(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.3(jiti@2.7.0))
       eslint-plugin-svelte:
         specifier: ^3.14.0
-        version: 3.15.0(eslint@9.39.3(jiti@2.6.1))(svelte@5.53.7)
+        version: 3.15.0(eslint@9.39.3(jiti@2.7.0))(svelte@5.53.7)
       globals:
         specifier: ^17.3.0
         version: 17.4.0
@@ -112,13 +112,13 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.54.0
-        version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       vitest-browser-svelte:
         specifier: ^2.0.2
         version: 2.0.2(svelte@5.53.7)(vitest@4.0.18)
@@ -145,23 +145,23 @@ importers:
         version: 3.19.19
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.13
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   packages/config:
     dependencies:
@@ -171,6 +171,9 @@ importers:
       effect:
         specifier: ^3.19.19
         version: 3.19.19
+      jiti:
+        specifier: ^2.7.0
+        version: 2.7.0
       semver:
         specifier: ^7.7.4
         version: 7.7.4
@@ -186,16 +189,16 @@ importers:
         version: 7.7.1
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   packages/core:
     dependencies:
@@ -205,16 +208,16 @@ importers:
     devDependencies:
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   packages/plugins:
     dependencies:
@@ -278,16 +281,16 @@ importers:
         version: 22.19.13
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   packages/reference:
     dependencies:
@@ -532,7 +535,7 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.2
-        version: 2.0.2(eslint@9.39.3(jiti@2.6.1))
+        version: 2.0.2(eslint@9.39.3(jiti@2.7.0))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.3
@@ -541,16 +544,16 @@ importers:
         version: 2.13.1
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
-        version: 7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
+        version: 7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
       '@sveltejs/kit':
         specifier: ^2.50.2
-        version: 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@sveltejs/package':
         specifier: ^2.5.7
         version: 2.5.7(svelte@5.53.7)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.1)
@@ -559,25 +562,25 @@ importers:
         version: 0.5.19(tailwindcss@4.2.1)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@types/node':
         specifier: ^24
         version: 24.11.0
       '@vitest/browser-playwright':
         specifier: ^4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.3(jiti@2.6.1)
+        version: 9.39.3(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.3(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.3(jiti@2.7.0))
       eslint-plugin-svelte:
         specifier: ^3.14.0
-        version: 3.15.0(eslint@9.39.3(jiti@2.6.1))(svelte@5.53.7)
+        version: 3.15.0(eslint@9.39.3(jiti@2.7.0))(svelte@5.53.7)
       globals:
         specifier: ^17.3.0
         version: 17.4.0
@@ -610,13 +613,13 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.54.0
-        version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       vitest-browser-svelte:
         specifier: ^2.0.2
         version: 2.0.2(svelte@5.53.7)(vitest@4.0.18)
@@ -641,19 +644,19 @@ importers:
         version: 22.19.13
       '@vitest/coverage-v8':
         specifier: ^3.0.0
-        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3)
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   themes/minimal:
     dependencies:
@@ -666,7 +669,7 @@ importers:
     devDependencies:
       '@eslint/compat':
         specifier: ^2.0.2
-        version: 2.0.2(eslint@9.39.3(jiti@2.6.1))
+        version: 2.0.2(eslint@9.39.3(jiti@2.7.0))
       '@eslint/js':
         specifier: ^9.39.2
         version: 9.39.3
@@ -675,16 +678,16 @@ importers:
         version: 2.13.1
       '@sveltejs/adapter-auto':
         specifier: ^7.0.0
-        version: 7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
+        version: 7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))
       '@sveltejs/kit':
         specifier: ^2.50.2
-        version: 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@sveltejs/package':
         specifier: ^2.5.7
         version: 2.5.7(svelte@5.53.7)(typescript@5.9.3)
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@tailwindcss/forms':
         specifier: ^0.5.11
         version: 0.5.11(tailwindcss@4.2.1)
@@ -693,25 +696,25 @@ importers:
         version: 0.5.19(tailwindcss@4.2.1)
       '@tailwindcss/vite':
         specifier: ^4.1.18
-        version: 4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+        version: 4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@types/node':
         specifier: ^24
         version: 24.11.0
       '@vitest/browser-playwright':
         specifier: ^4.0.18
-        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+        version: 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
+        version: 4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)
       eslint:
         specifier: ^9.39.2
-        version: 9.39.3(jiti@2.6.1)
+        version: 9.39.3(jiti@2.7.0)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.39.3(jiti@2.6.1))
+        version: 10.1.8(eslint@9.39.3(jiti@2.7.0))
       eslint-plugin-svelte:
         specifier: ^3.14.0
-        version: 3.15.0(eslint@9.39.3(jiti@2.6.1))(svelte@5.53.7)
+        version: 3.15.0(eslint@9.39.3(jiti@2.7.0))(svelte@5.53.7)
       globals:
         specifier: ^17.3.0
         version: 17.4.0
@@ -744,13 +747,13 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.54.0
-        version: 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+        version: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       vitest-browser-svelte:
         specifier: ^2.0.2
         version: 2.0.2(svelte@5.53.7)(vitest@4.0.18)
@@ -2203,6 +2206,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vitest/browser-playwright@4.0.18':
     resolution: {integrity: sha512-gfajTHVCiwpxRj1qh0Sh/5bbGLG4F/ZH/V9xvFVoFddpITfMta9YGow0W6ZpTTORv2vdJuz9TnrNSmjKvpOf4g==}
@@ -2297,10 +2301,12 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xmldom/xmldom@0.9.8':
     resolution: {integrity: sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3248,6 +3254,10 @@ packages:
 
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
   joycon@3.1.1:
@@ -4699,6 +4709,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@13.0.0:
@@ -5142,18 +5153,18 @@ snapshots:
   '@esbuild/win32-x64@0.27.3':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@9.39.3(jiti@2.7.0))':
     dependencies:
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/compat@2.0.2(eslint@9.39.3(jiti@2.6.1))':
+  '@eslint/compat@2.0.2(eslint@9.39.3(jiti@2.7.0))':
     dependencies:
       '@eslint/core': 1.1.0
     optionalDependencies:
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
 
   '@eslint/config-array@0.21.1':
     dependencies:
@@ -5779,34 +5790,34 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))':
+  '@sveltejs/adapter-auto@7.0.1(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))':
     dependencies:
-      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
 
-  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(wrangler@4.69.0)':
+  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(wrangler@4.69.0)':
     dependencies:
       '@cloudflare/workers-types': 4.20260301.1
-      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       worktop: 0.8.0-next.18
       wrangler: 4.69.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.59.0)
       '@rollup/plugin-json': 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.59.0)
-      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       rollup: 4.59.0
 
-  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))':
+  '@sveltejs/adapter-static@3.0.10(@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))':
     dependencies:
-      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@sveltejs/kit': 2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
 
-  '@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@sveltejs/kit@2.53.4(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(typescript@5.9.3)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -5818,7 +5829,7 @@ snapshots:
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
       svelte: 5.53.7
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     optionalDependencies:
       typescript: 5.9.3
 
@@ -5833,22 +5844,22 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       obug: 2.1.1
       svelte: 5.53.7
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)))(svelte@5.53.7)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.53.7
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
-      vitefu: 1.1.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitefu: 1.1.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
 
   '@tailwindcss/forms@0.5.11(tailwindcss@4.2.1)':
     dependencies:
@@ -5921,12 +5932,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.2.1
 
-  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.2.1(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.1
       '@tailwindcss/oxide': 4.2.1
       tailwindcss: 4.2.1
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   '@testing-library/svelte-core@1.0.0(svelte@5.53.7)':
     dependencies:
@@ -6139,15 +6150,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.56.1
-      '@typescript-eslint/type-utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -6155,14 +6166,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.56.1
       debug: 4.4.3
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -6185,13 +6196,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
       debug: 4.4.3
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
       ts-api-utils: 2.4.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -6214,13 +6225,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.56.1
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -6232,13 +6243,13 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - bufferutil
       - msw
@@ -6246,29 +6257,29 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
+  '@vitest/browser-playwright@4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
     dependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       playwright: 1.58.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - bufferutil
       - msw
       - utf-8-validate
       - vite
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -6277,16 +6288,16 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
+  '@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)':
     dependencies:
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@vitest/utils': 4.0.18
       magic-string: 0.30.21
       pixelmatch: 7.1.0
       pngjs: 7.0.0
       sirv: 3.0.2
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       ws: 8.19.0
     transitivePeerDependencies:
       - bufferutil
@@ -6294,7 +6305,7 @@ snapshots:
       - utf-8-validate
       - vite
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6309,11 +6320,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
@@ -6328,11 +6339,11 @@ snapshots:
       std-env: 3.10.0
       test-exclude: 7.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -6344,11 +6355,11 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
 
-  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)':
+  '@vitest/coverage-v8@4.0.18(@vitest/browser@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18))(vitest@4.0.18)':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -6360,9 +6371,9 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     optionalDependencies:
-      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+      '@vitest/browser': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -6381,37 +6392,37 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -6945,15 +6956,15 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@9.39.3(jiti@2.6.1)):
+  eslint-config-prettier@10.1.8(eslint@9.39.3(jiti@2.7.0)):
     dependencies:
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
 
-  eslint-plugin-svelte@3.15.0(eslint@9.39.3(jiti@2.6.1))(svelte@5.53.7):
+  eslint-plugin-svelte@3.15.0(eslint@9.39.3(jiti@2.7.0))(svelte@5.53.7):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.7.0))
       '@jridgewell/sourcemap-codec': 1.5.5
-      eslint: 9.39.3(jiti@2.6.1)
+      eslint: 9.39.3(jiti@2.7.0)
       esutils: 2.0.3
       globals: 16.5.0
       known-css-properties: 0.37.0
@@ -6978,9 +6989,9 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@9.39.3(jiti@2.6.1):
+  eslint@9.39.3(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.3(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
       '@eslint/config-array': 0.21.1
       '@eslint/config-helpers': 0.4.2
@@ -7015,7 +7026,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -7450,6 +7461,8 @@ snapshots:
       '@pkgjs/parseargs': 0.11.0
 
   jiti@2.6.1: {}
+
+  jiti@2.7.0: {}
 
   joycon@3.1.1: {}
 
@@ -8242,11 +8255,11 @@ snapshots:
     optionalDependencies:
       postcss: 8.5.8
 
-  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0):
+  postcss-load-config@6.0.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
-      jiti: 2.6.1
+      jiti: 2.7.0
       postcss: 8.5.8
       tsx: 4.21.0
 
@@ -9009,7 +9022,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -9020,7 +9033,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)
+      postcss-load-config: 6.0.1(jiti@2.7.0)(postcss@8.5.8)(tsx@4.21.0)
       resolve-from: 5.0.0
       rollup: 4.59.0
       source-map: 0.7.6
@@ -9075,13 +9088,13 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
 
-  typescript-eslint@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.56.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/typescript-estree': 8.56.1(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.3(jiti@2.6.1)
+      '@typescript-eslint/utils': 8.56.1(eslint@9.39.3(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.3(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -9219,13 +9232,13 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-node@3.2.4(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9240,13 +9253,13 @@ snapshots:
       - tsx
       - yaml
 
-  vite-node@3.2.4(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vite-node@3.2.4(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9261,7 +9274,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9272,13 +9285,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.13
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.31.1
       sass: 1.97.3
       sass-embedded: 1.97.3
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9289,13 +9302,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.11.0
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.31.1
       sass: 1.97.3
       sass-embedded: 1.97.3
       tsx: 4.21.0
 
-  vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vite@7.3.1(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.3
       fdir: 6.5.0(picomatch@4.0.3)
@@ -9306,27 +9319,27 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.3.5
       fsevents: 2.3.3
-      jiti: 2.6.1
+      jiti: 2.7.0
       lightningcss: 1.31.1
       sass: 1.97.3
       sass-embedded: 1.97.3
       tsx: 4.21.0
 
-  vitefu@1.1.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)):
+  vitefu@1.1.2(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
   vitest-browser-svelte@2.0.2(svelte@5.53.7)(vitest@4.0.18):
     dependencies:
       '@testing-library/svelte-core': 1.0.0(svelte@5.53.7)
       svelte: 5.53.7
-      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vitest: 4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9344,8 +9357,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -9364,11 +9377,11 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -9386,8 +9399,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
-      vite-node: 3.2.4(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@25.3.5)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -9406,10 +9419,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vitest@4.0.18(@types/node@22.19.13)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -9426,11 +9439,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.13
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@22.19.13)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
     transitivePeerDependencies:
       - jiti
       - less
@@ -9444,10 +9457,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
+  vitest@4.0.18(@types/node@24.11.0)(@vitest/browser-playwright@4.0.18)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -9464,11 +9477,11 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.11.0
-      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.6.1)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
+      '@vitest/browser-playwright': 4.0.18(playwright@1.58.2)(vite@7.3.1(@types/node@24.11.0)(jiti@2.7.0)(lightningcss@1.31.1)(sass-embedded@1.97.3)(sass@1.97.3)(tsx@4.21.0))(vitest@4.0.18)
     transitivePeerDependencies:
       - jiti
       - less

--- a/svartz.config.ts
+++ b/svartz.config.ts
@@ -12,19 +12,9 @@ export default defineConfig({
       target: {
         type: "static",
       },
-    },
-    {
-      id: "obsidian-journal",
-      path: "vaults/obsidian-journal",
-      target: {
-        type: "static",
-      },
-    },
-    {
-      id: "vault",
-      path: "vaults/vault",
-      target: {
-        type: "static",
+      site: {
+        title: "Svartz Documentation",
+        description: "Documentation for the Svartz static publishing toolkit.",
       },
     },
   ],

--- a/themes/minimal/package.json
+++ b/themes/minimal/package.json
@@ -3,7 +3,7 @@
 	"version": "0.0.1",
 	"scripts": {
 		"dev": "vite dev",
-		"build": "vite build && pnpm run prepack",
+		"build": "vite build && svelte-kit sync && svelte-package && publint",
 		"preview": "vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"prepack": "svelte-kit sync && svelte-package && publint",

--- a/themes/minimal/package.json
+++ b/themes/minimal/package.json
@@ -33,6 +33,12 @@
 			"svelte": "./dist/index.js",
 			"import": "./dist/index.js",
 			"default": "./dist/index.js"
+		},
+		"./runtime": {
+			"types": "./dist/runtime.d.ts",
+			"svelte": "./dist/runtime.js",
+			"import": "./dist/runtime.js",
+			"default": "./dist/runtime.js"
 		}
 	},
 	"peerDependencies": {

--- a/themes/minimal/src/lib/index.test.ts
+++ b/themes/minimal/src/lib/index.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import createMinimalTheme from './runtime';
+
+describe('@svartz/theme-minimal runtime modules', () => {
+	it('exposes eager layout, route, and shared component modules for SSR', () => {
+		const theme = createMinimalTheme();
+
+		for (const layout of Object.values(theme.layouts)) {
+			if (!layout) continue;
+			expect(typeof layout).toBe('object');
+			expect(layout).toHaveProperty('default');
+		}
+
+		for (const route of theme.routes) {
+			if (!route.component) continue;
+			expect(typeof route.component).toBe('object');
+			expect(route.component).toHaveProperty('default');
+		}
+
+		for (const component of Object.values(theme.components ?? {})) {
+			if (!component) continue;
+			expect(typeof component).toBe('object');
+			expect(component).toHaveProperty('default');
+		}
+	});
+});

--- a/themes/minimal/src/lib/index.ts
+++ b/themes/minimal/src/lib/index.ts
@@ -1,8 +1,13 @@
 import { defineTheme, type ThemeComponentLoader } from '@svartz/core';
+import {
+	createMinimalTheme,
+	type MinimalRouteConfig,
+	type MinimalThemeConfig,
+	type MinimalThemeModules
+} from './manifest.js';
 
 type ComponentModule = { default: unknown };
 
-// Static dynamic imports so the bundler can emit chunks; variable import(moduleId) cannot be code-split.
 const loadSiteLayout = (): Promise<ComponentModule> =>
 	import('./layouts/SiteLayout.svelte') as Promise<ComponentModule>;
 const loadNotFoundPage = (): Promise<ComponentModule> =>
@@ -20,114 +25,28 @@ const loadFeedPage = (): Promise<ComponentModule> =>
 
 const loadFromUi = (exportName: string): ThemeComponentLoader =>
 	(() =>
-		import('@svartz/ui').then((m) => ({
-			default: (m as Record<string, unknown>)[exportName]
+		import('@svartz/ui').then((module) => ({
+			default: (module as Record<string, unknown>)[exportName]
 		}))) as () => Promise<ComponentModule>;
 
-/** Route prefix configuration — keys become URL path segments. */
-export interface MinimalRouteConfig {
-	/** Prefix for tag pages. Default: `"tags"` → `/tags/`, `/tags/:slug`. */
-	tags?: string;
-	/** Prefix for folder pages. Default: `"folders"` → `/folders/`, `/folders/:slug`. */
-	folders?: string;
-	/** Prefix for the chronological feed page. Default: `"feed"` → `/feed/`. */
-	feed?: string;
-}
+const modules: MinimalThemeModules = {
+	siteLayout: loadSiteLayout,
+	notFoundPage: loadNotFoundPage,
+	tagListPage: loadTagListPage,
+	tagPage: loadTagPage,
+	folderListPage: loadFolderListPage,
+	folderPage: loadFolderPage,
+	feedPage: loadFeedPage,
+	backlinks: loadFromUi('Backlinks'),
+	comments: loadFromUi('Comments'),
+	graphPanel: loadFromUi('GraphPanel'),
+	recentNotes: loadFromUi('RecentNotes'),
+	searchBox: loadFromUi('SearchBox'),
+	toc: loadFromUi('TableOfContents'),
+	noteHeader: loadFromUi('NoteHeader')
+};
 
-export interface MinimalThemeConfig {
-	routes?: MinimalRouteConfig;
-	[key: string]: unknown;
-}
+export type { MinimalRouteConfig, MinimalThemeConfig } from './manifest.js';
 
-/**
- * Factory exported as `default`. The Svartz Vite plugin calls this at module
- * evaluation time with the vault's `theme.*` config (minus `base`), so route
- * patterns reflect vault-level customisation.
- *
- * Themes that don't need dynamic routes can still export a static `SvartzTheme`
- * object — the runtime handles both.
- */
-export default defineTheme((config?: MinimalThemeConfig) => {
-	const tags = config?.routes?.tags ?? 'tags';
-	const folders = config?.routes?.folders ?? 'folders';
-	const feed = config?.routes?.feed ?? 'feed';
-
-	return {
-		id: '@svartz/theme-minimal',
-		displayName: 'Svartz Minimal',
-		description: 'Quartz-like starter theme for Svartz static vault sites.',
-		version: '0.0.1',
-		contractVersion: '1.0.0',
-		layouts: {
-			defaultPage: loadSiteLayout,
-			notePage: loadSiteLayout,
-			tagPage: loadSiteLayout,
-			folderPage: loadSiteLayout,
-			feedPage: loadSiteLayout,
-			notFoundPage: loadNotFoundPage
-		},
-		routes: [
-			{ id: 'home', pattern: '/', layoutSlot: 'notePage', priority: 100 },
-			{
-				id: 'tags-index',
-				pattern: `/${tags}`,
-				layoutSlot: 'defaultPage',
-				component: loadTagListPage,
-				priority: 90
-			},
-			{
-				id: 'tag',
-				pattern: `/${tags}/:slug`,
-				layoutSlot: 'tagPage',
-				component: loadTagPage,
-				priority: 80
-			},
-			{
-				id: 'feed',
-				pattern: `/${feed}`,
-				layoutSlot: 'feedPage',
-				component: loadFeedPage,
-				priority: 75
-			},
-			{
-				id: 'folders-index',
-				pattern: `/${folders}`,
-				layoutSlot: 'defaultPage',
-				component: loadFolderListPage,
-				priority: 70
-			},
-			{
-				id: 'folder',
-				pattern: `/${folders}/:slug`,
-				layoutSlot: 'folderPage',
-				component: loadFolderPage,
-				priority: 60
-			},
-			{ id: 'note', pattern: '/:slug', layoutSlot: 'notePage', priority: 10 }
-		],
-		components: {
-			backlinks: loadFromUi('Backlinks'),
-			comments: loadFromUi('Comments'),
-			graphPanel: loadFromUi('GraphPanel'),
-			recentNotes: loadFromUi('RecentNotes'),
-			searchBox: loadFromUi('SearchBox'),
-			toc: loadFromUi('TableOfContents'),
-			noteHeader: loadFromUi('NoteHeader')
-		},
-		capabilities: {
-			embeds: true,
-			codeBlocks: true,
-			syntaxHighlighting: true,
-			math: true,
-			toc: true,
-			backlinks: true,
-			graph: true,
-			search: true
-		},
-		artifactRequirements: {
-			index: true,
-			graph: true,
-			backlinks: true
-		}
-	};
-});
+/** Node-safe manifest used by the build pipeline. */
+export default defineTheme((config?: MinimalThemeConfig) => createMinimalTheme(modules, config));

--- a/themes/minimal/src/lib/layouts/SiteLayout.svelte
+++ b/themes/minimal/src/lib/layouts/SiteLayout.svelte
@@ -5,7 +5,6 @@
 		Breadcrumbs,
 		Comments,
 		FileTrie,
-		GraphPanel,
 		NoteHeader,
 		RecentNotes,
 		SearchBox,
@@ -63,7 +62,6 @@
 		entry,
 		index = { entries: [], backlinks: {}, graph: {} },
 		backlinks = {},
-		graph = {},
 		match,
 		searchDocuments = [],
 		searchIndex,
@@ -73,7 +71,6 @@
 		entry?: Entry;
 		index?: Index;
 		backlinks?: Record<string, readonly string[]>;
-		graph?: Record<string, readonly string[]>;
 		match?: { pathname?: string; params?: { slug?: string } };
 		searchDocuments?: readonly {
 			id: string;
@@ -107,13 +104,14 @@
 	const breadcrumbSlug = $derived(pathnameToSlug(match?.pathname));
 </script>
 
+<a class="skip-link" href="#main-content">Skip to content</a>
 <div class="shell">
-	<aside class="left-sidebar">
+	<aside class="left-sidebar" aria-label="Site navigation">
 		<SearchBox {searchDocuments} {searchIndex} />
 		<FileTrie entries={index.entries} currentSlug={breadcrumbSlug} />
 	</aside>
 
-	<div class="content-column">
+	<main class="content-column" id="main-content" tabindex="-1">
 		<Breadcrumbs slug={breadcrumbSlug} />
 		{#if entry}
 			<NoteHeader {entry} />
@@ -136,9 +134,9 @@
 				darkTheme={cfg.comments!.darkTheme}
 			/>
 		{/if}
-	</div>
+	</main>
 
-	<aside class="right-sidebar">
+	<aside class="right-sidebar" aria-label="Related content">
 		<TableOfContents items={entry?.toc} />
 		{#if recentNotesEnabled}
 			<RecentNotes
@@ -148,15 +146,31 @@
 				linkToMore={cfg.recentNotes?.linkToMore ?? '/feed/'}
 			/>
 		{/if}
-		<GraphPanel currentSlug={entry?.slug} entries={index.entries} {graph} />
 		<Backlinks currentSlug={entry?.slug} entries={index.entries} {backlinks} />
 	</aside>
 </div>
 
 <style>
 	:global(body) {
-		background: #0f1117;
-		color: #f8fafc;
+		background: #fafafa;
+		color: #18181b;
+	}
+
+	.skip-link {
+		position: fixed;
+		top: 0.75rem;
+		left: 0.75rem;
+		z-index: 50;
+		transform: translateY(-200%);
+		border-radius: 0.5rem;
+		background: #f8fafc;
+		color: #0f172a;
+		padding: 0.6rem 0.85rem;
+		font-weight: 600;
+	}
+
+	.skip-link:focus {
+		transform: translateY(0);
 	}
 
 	.shell {
@@ -192,7 +206,9 @@
 
 	.content-column {
 		grid-area: content;
+		width: min(100%, 52rem);
 		min-width: 0;
+		justify-self: center;
 	}
 
 	.right-sidebar {
@@ -200,11 +216,8 @@
 	}
 
 	.page-body {
-		background: rgba(255, 255, 255, 0.02);
-		border: 1px solid rgba(255, 255, 255, 0.06);
-		border-radius: 1rem;
 		min-width: 0;
-		padding: clamp(1rem, 3vw, 2rem);
+		padding: clamp(0.25rem, 1vw, 0.75rem) 0;
 	}
 
 	.page-body :global(h1),
@@ -212,10 +225,63 @@
 	.page-body :global(h3),
 	.page-body :global(h4) {
 		line-height: 1.2;
+		font-weight: 700;
+		letter-spacing: -0.02em;
+		text-wrap: balance;
+	}
+
+	.page-body :global(h1) {
+		margin: 0 0 1.25rem;
+		font-size: clamp(1.8rem, 4vw, 2.35rem);
+	}
+
+	.page-body :global(h2) {
+		margin: 2.75rem 0 0.9rem;
+		font-size: clamp(1.4rem, 3vw, 1.75rem);
+	}
+
+	.page-body :global(h3) {
+		margin: 2rem 0 0.7rem;
+		font-size: 1.2rem;
+	}
+
+	.page-body :global(h4) {
+		margin: 1.5rem 0 0.5rem;
+		font-size: 1rem;
+	}
+
+	.page-body :global(p),
+	.page-body :global(ul),
+	.page-body :global(ol) {
+		margin: 0.85rem 0;
+	}
+
+	.page-body :global(ul),
+	.page-body :global(ol) {
+		padding-left: 1.4rem;
+	}
+
+	.page-body :global(ul) {
+		list-style: disc;
+	}
+
+	.page-body :global(ol) {
+		list-style: decimal;
+	}
+
+	.page-body :global(li) {
+		margin: 0.35rem 0;
+		padding-left: 0.15rem;
+	}
+
+	.page-body :global(hr) {
+		margin: 2.5rem 0;
+		border: 0;
+		border-top: 1px solid #e4e4e7;
 	}
 
 	.page-body :global(a) {
-		color: #c4b5fd;
+		color: #6d28d9;
 	}
 
 	.page-body :global(pre) {
@@ -223,14 +289,32 @@
 		overflow: auto;
 		padding: 1rem;
 		border-radius: 0.75rem;
-		background: rgba(15, 23, 42, 0.9);
+		background: #18181b;
+		color: #fafafa;
 	}
 
 	.page-body :global(blockquote) {
 		margin: 1rem 0;
 		padding: 0.85rem 1rem;
-		border-left: 3px solid rgba(196, 181, 253, 0.75);
-		background: rgba(255, 255, 255, 0.03);
+		border-left: 3px solid #8b5cf6;
+		background: #f4f4f5;
+	}
+
+	.page-body :global(blockquote:has(.callout-marker)) {
+		border: 1px solid #ddd6fe;
+		border-left: 3px solid #8b5cf6;
+		border-radius: 0.6rem;
+	}
+
+	.page-body :global(.callout-marker + strong) {
+		display: inline-block;
+		margin-bottom: 0.35rem;
+		color: #6d28d9;
+	}
+
+	.page-body :global(.callout-marker[data-callout='warning'] + strong),
+	.page-body :global(.callout-marker[data-callout='caution'] + strong) {
+		color: #92400e;
 	}
 
 	.page-body :global(mark) {
@@ -256,16 +340,26 @@
 	@media (max-width: 62rem) {
 		.shell {
 			grid-template-areas:
-				'left'
 				'content'
+				'left'
 				'right';
 			grid-template-columns: minmax(0, 1fr);
+			padding: clamp(0.75rem, 3vw, 1.25rem);
+		}
+
+		.page-body {
+			border: 0;
+			border-radius: 0;
+			background: transparent;
+			padding: 0;
 		}
 
 		.left-sidebar,
 		.right-sidebar {
 			position: static;
 			max-height: none;
+			border-top: 1px solid #e4e4e7;
+			padding-top: 1.25rem;
 		}
 	}
 </style>

--- a/themes/minimal/src/lib/manifest.ts
+++ b/themes/minimal/src/lib/manifest.ts
@@ -1,0 +1,121 @@
+import type { SvartzTheme, ThemeComponentLoader } from '@svartz/core';
+
+/** Route prefix configuration — keys become URL path segments. */
+export interface MinimalRouteConfig {
+	/** Prefix for tag pages. Default: `"tags"` → `/tags/`, `/tags/:slug`. */
+	tags?: string;
+	/** Prefix for folder pages. Default: `"folders"` → `/folders/`, `/folders/:slug`. */
+	folders?: string;
+	/** Prefix for the chronological feed page. Default: `"feed"` → `/feed/`. */
+	feed?: string;
+}
+
+export interface MinimalThemeConfig {
+	routes?: MinimalRouteConfig;
+	[key: string]: unknown;
+}
+
+export interface MinimalThemeModules {
+	readonly siteLayout: ThemeComponentLoader;
+	readonly notFoundPage: ThemeComponentLoader;
+	readonly tagListPage: ThemeComponentLoader;
+	readonly tagPage: ThemeComponentLoader;
+	readonly folderListPage: ThemeComponentLoader;
+	readonly folderPage: ThemeComponentLoader;
+	readonly feedPage: ThemeComponentLoader;
+	readonly backlinks: ThemeComponentLoader;
+	readonly comments: ThemeComponentLoader;
+	readonly graphPanel: ThemeComponentLoader;
+	readonly recentNotes: ThemeComponentLoader;
+	readonly searchBox: ThemeComponentLoader;
+	readonly toc: ThemeComponentLoader;
+	readonly noteHeader: ThemeComponentLoader;
+}
+
+export function createMinimalTheme(
+	modules: MinimalThemeModules,
+	config?: MinimalThemeConfig
+): SvartzTheme {
+	const tags = config?.routes?.tags ?? 'tags';
+	const folders = config?.routes?.folders ?? 'folders';
+	const feed = config?.routes?.feed ?? 'feed';
+
+	return {
+		id: '@svartz/theme-minimal',
+		displayName: 'Svartz Minimal',
+		description: 'Quartz-like starter theme for Svartz static vault sites.',
+		version: '0.0.1',
+		contractVersion: '1.0.0',
+		layouts: {
+			defaultPage: modules.siteLayout,
+			notePage: modules.siteLayout,
+			tagPage: modules.siteLayout,
+			folderPage: modules.siteLayout,
+			feedPage: modules.siteLayout,
+			notFoundPage: modules.notFoundPage
+		},
+		routes: [
+			{ id: 'home', pattern: '/', layoutSlot: 'notePage', priority: 100 },
+			{
+				id: 'tags-index',
+				pattern: `/${tags}`,
+				layoutSlot: 'defaultPage',
+				component: modules.tagListPage,
+				priority: 90
+			},
+			{
+				id: 'tag',
+				pattern: `/${tags}/:slug`,
+				layoutSlot: 'tagPage',
+				component: modules.tagPage,
+				priority: 80
+			},
+			{
+				id: 'feed',
+				pattern: `/${feed}`,
+				layoutSlot: 'feedPage',
+				component: modules.feedPage,
+				priority: 75
+			},
+			{
+				id: 'folders-index',
+				pattern: `/${folders}`,
+				layoutSlot: 'defaultPage',
+				component: modules.folderListPage,
+				priority: 70
+			},
+			{
+				id: 'folder',
+				pattern: `/${folders}/:slug`,
+				layoutSlot: 'folderPage',
+				component: modules.folderPage,
+				priority: 60
+			},
+			{ id: 'note', pattern: '/:slug', layoutSlot: 'notePage', priority: 10 }
+		],
+		components: {
+			backlinks: modules.backlinks,
+			comments: modules.comments,
+			graphPanel: modules.graphPanel,
+			recentNotes: modules.recentNotes,
+			searchBox: modules.searchBox,
+			toc: modules.toc,
+			noteHeader: modules.noteHeader
+		},
+		capabilities: {
+			embeds: true,
+			codeBlocks: true,
+			syntaxHighlighting: true,
+			math: true,
+			toc: true,
+			backlinks: true,
+			graph: true,
+			search: true
+		},
+		artifactRequirements: {
+			index: true,
+			graph: true,
+			backlinks: true
+		}
+	};
+}

--- a/themes/minimal/src/lib/pages/FeedPage.svelte
+++ b/themes/minimal/src/lib/pages/FeedPage.svelte
@@ -4,8 +4,8 @@
 		title: string;
 		description?: string;
 		tags?: readonly string[];
-		modifiedAt?: Date;
-		createdAt?: Date;
+		modifiedAt?: Date | string;
+		createdAt?: Date | string;
 		readingTimeMinutes?: number;
 	};
 
@@ -29,7 +29,8 @@
 	const feedDescription = $derived(metaEntry?.description);
 
 	function noteDate(entry: Entry): Date | undefined {
-		return entry.modifiedAt ?? entry.createdAt;
+		const value = entry.modifiedAt ?? entry.createdAt;
+		return value ? new Date(value) : undefined;
 	}
 
 	function formatDate(d: Date): string {
@@ -73,10 +74,10 @@
 		{#each notes as entry (entry.slug)}
 			{@const date = noteDate(entry)}
 			<li class="grid gap-1.5 border-b border-zinc-100 py-4 last:border-0 dark:border-zinc-800">
-				<div class="flex items-baseline justify-between gap-4">
+				<div class="flex min-w-0 flex-col items-start gap-1 sm:flex-row sm:items-baseline sm:justify-between sm:gap-4">
 					<a
 						href={slugToHref(entry.slug)}
-						class="font-medium leading-snug text-zinc-900 transition-colors hover:text-blue-600 dark:text-zinc-100 dark:hover:text-blue-400"
+						class="min-w-0 [overflow-wrap:anywhere] font-medium leading-snug text-zinc-900 transition-colors hover:text-blue-600 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-violet-600 dark:text-zinc-100 dark:hover:text-blue-400"
 					>
 						{entry.title}
 					</a>

--- a/themes/minimal/src/lib/runtime.ts
+++ b/themes/minimal/src/lib/runtime.ts
@@ -1,0 +1,38 @@
+import { defineTheme } from '@svartz/core';
+import {
+	Backlinks,
+	Comments,
+	GraphPanel,
+	NoteHeader,
+	RecentNotes,
+	SearchBox,
+	TableOfContents
+} from '@svartz/ui';
+import SiteLayout from './layouts/SiteLayout.svelte';
+import { createMinimalTheme, type MinimalThemeConfig, type MinimalThemeModules } from './manifest.js';
+import FeedPage from './pages/FeedPage.svelte';
+import FolderListPage from './pages/FolderListPage.svelte';
+import FolderPage from './pages/FolderPage.svelte';
+import NotFoundPage from './pages/NotFoundPage.svelte';
+import TagListPage from './pages/TagListPage.svelte';
+import TagPage from './pages/TagPage.svelte';
+
+const modules: MinimalThemeModules = {
+	siteLayout: { default: SiteLayout },
+	notFoundPage: { default: NotFoundPage },
+	tagListPage: { default: TagListPage },
+	tagPage: { default: TagPage },
+	folderListPage: { default: FolderListPage },
+	folderPage: { default: FolderPage },
+	feedPage: { default: FeedPage },
+	backlinks: { default: Backlinks },
+	comments: { default: Comments },
+	graphPanel: { default: GraphPanel },
+	recentNotes: { default: RecentNotes },
+	searchBox: { default: SearchBox },
+	toc: { default: TableOfContents },
+	noteHeader: { default: NoteHeader }
+};
+
+/** Vite-bundled runtime manifest with eager components for SSR and hydration. */
+export default defineTheme((config?: MinimalThemeConfig) => createMinimalTheme(modules, config));

--- a/themes/minimal/src/lib/runtime.ts
+++ b/themes/minimal/src/lib/runtime.ts
@@ -35,4 +35,7 @@ const modules: MinimalThemeModules = {
 };
 
 /** Vite-bundled runtime manifest with eager components for SSR and hydration. */
-export default defineTheme((config?: MinimalThemeConfig) => createMinimalTheme(modules, config));
+const theme = defineTheme((config?: MinimalThemeConfig) => createMinimalTheme(modules, config));
+
+export { theme };
+export default theme;

--- a/turbo.json
+++ b/turbo.json
@@ -65,9 +65,7 @@
     },
     "//#svartz:build": {
       "dependsOn": [
-        "//#svartz:build:docs",
-        "//#svartz:build:obsidian-journal",
-        "//#svartz:build:vault"
+        "//#svartz:build:docs"
       ]
     },
     "//#svartz:build:docs": {
@@ -90,54 +88,6 @@
     "//#svartz:preview:docs": {
       "dependsOn": [
         "//#svartz:build:docs"
-      ],
-      "cache": false,
-      "persistent": true
-    },
-    "//#svartz:build:obsidian-journal": {
-      "inputs": [
-        "apps/web/**",
-        "package.json",
-        "pnpm-lock.yaml",
-        "svartz.config.*",
-        ".svartzrc.*",
-        "vaults/obsidian-journal/**"
-      ],
-      "outputs": [
-        ".svartz/vaults/obsidian-journal/dist/**"
-      ]
-    },
-    "//#svartz:dev:obsidian-journal": {
-      "cache": false,
-      "persistent": true
-    },
-    "//#svartz:preview:obsidian-journal": {
-      "dependsOn": [
-        "//#svartz:build:obsidian-journal"
-      ],
-      "cache": false,
-      "persistent": true
-    },
-    "//#svartz:build:vault": {
-      "inputs": [
-        "apps/web/**",
-        "package.json",
-        "pnpm-lock.yaml",
-        "svartz.config.*",
-        ".svartzrc.*",
-        "vaults/vault/**"
-      ],
-      "outputs": [
-        ".svartz/vaults/vault/dist/**"
-      ]
-    },
-    "//#svartz:dev:vault": {
-      "cache": false,
-      "persistent": true
-    },
-    "//#svartz:preview:vault": {
-      "dependsOn": [
-        "//#svartz:build:vault"
       ],
       "cache": false,
       "persistent": true

--- a/vaults/docs/contracts/plugin-contract.md
+++ b/vaults/docs/contracts/plugin-contract.md
@@ -402,5 +402,5 @@ export function discoverFiles(): SvartzPlugin {
 ## See Also
 
 - [[contracts/theme-contract]] — Companion contract for themes
-- [[plugins/utilities]] — Implementation of utility functions
+- `plugins/utilities` — Implementation of utility functions
 - [[reference/quick-reference]] — Code examples

--- a/vaults/docs/index.md
+++ b/vaults/docs/index.md
@@ -26,7 +26,7 @@ Reference for all core plugins:
 
 - **[[plugins/overview]]** — Quick lookup table, stage breakdown
 - **[[plugins/discover-files]]** — Vault discovery and slug generation
-- **[[plugins/utilities]]** — Internal utilities (slug, ignore, parse, resolve)
+- **`plugins/utilities`** — Internal utilities (slug, ignore, parse, resolve)
 
 ### 📖 Reference
 
@@ -147,7 +147,7 @@ See [[contracts/plugin-contract]], [[contracts/theme-contract]]
 - Internal utilities (slug, ignore, parse, resolve)
 - All plugins use `definePlugin()` factory
 
-See [[plugins/overview]], [[plugins/utilities]]
+See [[plugins/overview]], `plugins/utilities`
 
 ### `@svartz/config`
 

--- a/vaults/docs/plugins/overview.md
+++ b/vaults/docs/plugins/overview.md
@@ -337,6 +337,6 @@ const corePlugins = createCorePlugins();
 ## See Also
 
 - [[contracts/plugin-contract]] — Plugin system contract
-- [[plugins/utilities]] — mergePlugins, sortPluginsForStage, etc.
+- `plugins/utilities` — mergePlugins, sortPluginsForStage, etc.
 - [[plugins/utilities/slug]] — Slug generation algorithm
 - [[plugins/utilities/ignore]] — Gitignore pattern matching

--- a/vaults/docs/reference/IMPLEMENTATION-SUMMARY.md
+++ b/vaults/docs/reference/IMPLEMENTATION-SUMMARY.md
@@ -19,7 +19,7 @@ Svartz documentation vault (`vaults/docs`) containing complete reference for @sv
 
 6. **[[plugins/overview]]** — All 12 core plugins reference with quick lookup table
 7. **[[plugins/discover-files]]** — Core discover plugin (first stage)
-8. **[[plugins/utilities]]** — Plugin utilities and internal modules
+8. **`plugins/utilities`** — Plugin utilities and internal modules
 
 ## Coverage
 

--- a/vaults/docs/reference/quick-reference.md
+++ b/vaults/docs/reference/quick-reference.md
@@ -427,4 +427,4 @@ type ConfigValidationError = {
 - [[contracts/theme-contract]] — Full theme system spec
 - [[contracts/config-contract]] — Full config spec
 - [[plugins/overview]] — All core plugins
-- [[plugins/utilities]] — Utility functions
+- `plugins/utilities` — Utility functions


### PR DESCRIPTION
## Goal

Bring Svartz to an MVP-ready baseline for launching a real personal blog, repairing the existing pipeline/runtime/UI rather than widening scope.

## Completed

- prerender complete article + theme HTML; no permanent `Loading...` shell
- repair OFM blockquotes/callouts and protect fenced, inline, indented, and blockquoted code
- activate GFM compilation and add pipeline integration coverage
- add site/page title, description, canonical, OpenGraph/Twitter, article-date metadata, and sitemap
- add validated HTTP(S) site URL config plus explicit opt-in publication mode
- make clean-output CLI builds reliable and emit `404.html`
- remove private local vaults from repository config/build tasks
- flatten the minimal theme content surface; improve article typography, spacing, lists, code, callouts, and responsive feed rows
- fix search dialog semantics/focus handling and invalid nested TOC interactions
- remove the cramped graph from the default layout while keeping the component available
- clean unresolved docs wikilinks

## UI direction

- established `@svartz/ui` primitives first
- whitespace and typography before borders/containers
- no card-in-card-in-card sludge
- shadcn-svelte/Bits remain available where they replace bespoke interaction code

## Deferred

- additional themes, Vite+ migration, plugin ecosystem expansion, fine-grained HMR, full Quartz parity, i18n, graph/search polish
- production domain and actual blog vault/deploy config (requires launch inputs)

## Validation

- [x] full monorepo test suite: 16/16 Turbo tasks
- [x] package build: 7/7 Turbo tasks
- [x] CLI clean-output E2E build
- [x] 45 generated HTML files including `404.html`
- [x] static HTML contains article content + metadata and no loading placeholder
- [x] desktop browser smoke + visual review
- [x] responsive layout rules and accessible search/TOC interactions

Draft until the real blog vault/domain/deployment are wired.